### PR TITLE
Request ssh key password, if it is not set, but the key is encrypted

### DIFF
--- a/pass/Controllers/SSHKeySettingTableViewController.swift
+++ b/pass/Controllers/SSHKeySettingTableViewController.swift
@@ -18,7 +18,7 @@ class SSHKeySettingTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        passphraseTextField.text = Defaults[.gitRepositorySSHPrivateKeyPassphrase]
+        passphraseTextField.text = Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!
         privateKeyURLTextField.text = Defaults[.gitRepositorySSHPrivateKeyURL]?.absoluteString
         publicKeyURLTextField.text = Defaults[.gitRepositorySSHPublicKeyURL]?.absoluteString
         var doneBarButtonItem: UIBarButtonItem?
@@ -43,7 +43,7 @@ class SSHKeySettingTableViewController: UITableViewController {
         
         Defaults[.gitRepositorySSHPublicKeyURL] = URL(string: publicKeyURLTextField.text!)
         Defaults[.gitRepositorySSHPrivateKeyURL] = URL(string: privateKeyURLTextField.text!)
-        Defaults[.gitRepositorySSHPrivateKeyPassphrase] = passphraseTextField.text!
+        Utils.addPasswrodToKeychain(name: "gitRepositorySSHPrivateKeyPassphrase", password: passphraseTextField.text!)
         
         do {
             try Data(contentsOf: Defaults[.gitRepositorySSHPublicKeyURL]!).write(to: Globals.sshPublicKeyURL, options: .atomic)

--- a/pass/Controllers/SettingsTableViewController.swift
+++ b/pass/Controllers/SettingsTableViewController.swift
@@ -116,7 +116,7 @@ class SettingsTableViewController: UITableViewController {
                     gitCredential = GitCredential(
                         credential: GitCredential.Credential.ssh(
                             userName: username,
-                            password: Defaults[.gitRepositorySSHPrivateKeyPassphrase]!,
+                            password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!,
                             publicKeyFile: Globals.sshPublicKeyURL,
                             privateKeyFile: Globals.sshPrivateKeyURL,
                             passwordNotSetCallback: self.requestSshKeyPassword

--- a/pass/Helpers/DefaultsKeys.swift
+++ b/pass/Helpers/DefaultsKeys.swift
@@ -26,7 +26,7 @@ extension DefaultsKeys {
     static let gitRepositoryPasswordAttempts = DefaultsKey<Int>("gitRepositoryPasswordAttempts")
     static let gitRepositorySSHPublicKeyURL = DefaultsKey<URL?>("gitRepositorySSHPublicKeyURL")
     static let gitRepositorySSHPrivateKeyURL = DefaultsKey<URL?>("gitRepositorySSHPrivateKeyURL")
-    static let gitRepositorySSHPrivateKeyPassphrase = DefaultsKey<String?>("gitRepositorySSHPrivateKeyPassphrase")
+
     static let lastUpdatedTime = DefaultsKey<Date?>("lasteUpdatedTime")
     
     static let isTouchIDOn = DefaultsKey<Bool>("isTouchIDOn")

--- a/pass/Models/PasswordStore.swift
+++ b/pass/Models/PasswordStore.swift
@@ -77,13 +77,14 @@ struct GitCredential {
                     newPassword = passwordNotSetCallback!()
                 }
 
+                // Save password for the future
+                Utils.addPasswrodToKeychain(name: "gitRepositorySSHPrivateKeyPassphrase", password: newPassword!)
+
                 // nil is expected in case of empty password
                 if newPassword == "" {
                     newPassword = nil
                 }
 
-                // Save password for the future
-                Defaults[.gitRepositorySSHPrivateKeyPassphrase] = newPassword
 
                 credential = try? GTCredential(userName: userName, publicKeyURL: publicKeyFile, privateKeyURL: privateKeyFile, passphrase: newPassword)
             }
@@ -141,7 +142,7 @@ class PasswordStore {
             gitCredential = GitCredential(
                 credential: GitCredential.Credential.ssh(
                     userName: Defaults[.gitRepositoryUsername]!,
-                    password: Defaults[.gitRepositorySSHPrivateKeyPassphrase]!,
+                    password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!,
                     publicKeyFile: Globals.sshPublicKeyURL,
                     privateKeyFile: Globals.sshPrivateKeyURL,
                     passwordNotSetCallback: nil


### PR DESCRIPTION
This makes some preparations for #22. If I upload the ssh key using iTunes there is no way to set the password for the ssh key if it is encrypted.

I've made it so the password is requested when the user saves the git repository settings.

I have also moved the code that interacts with the user to the ViewController, so the Model does not rely on the particular implementation. I am not an expert in swift, but this seems to be cleaner. I would be glad if you correct any mistakes i've made. I am trying to delve into iOS development :)