### PR TITLE
Fix a bug, that caused the app to crash if ssh passphrase is not set.

### DIFF
--- a/pass/Controllers/SSHKeySettingTableViewController.swift
+++ b/pass/Controllers/SSHKeySettingTableViewController.swift
@@ -18,7 +18,7 @@ class SSHKeySettingTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        passphraseTextField.text = Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!
+        passphraseTextField.text = Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase") ?? ""
         privateKeyURLTextField.text = Defaults[.gitRepositorySSHPrivateKeyURL]?.absoluteString
         publicKeyURLTextField.text = Defaults[.gitRepositorySSHPublicKeyURL]?.absoluteString
         var doneBarButtonItem: UIBarButtonItem?

--- a/pass/Controllers/SettingsTableViewController.swift
+++ b/pass/Controllers/SettingsTableViewController.swift
@@ -116,7 +116,7 @@ class SettingsTableViewController: UITableViewController {
                     gitCredential = GitCredential(
                         credential: GitCredential.Credential.ssh(
                             userName: username,
-                            password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!,
+                            password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase") ?? "",
                             publicKeyFile: Globals.sshPublicKeyURL,
                             privateKeyFile: Globals.sshPrivateKeyURL,
                             passwordNotSetCallback: self.requestSshKeyPassword

--- a/pass/Models/PasswordStore.swift
+++ b/pass/Models/PasswordStore.swift
@@ -142,7 +142,7 @@ class PasswordStore {
             gitCredential = GitCredential(
                 credential: GitCredential.Credential.ssh(
                     userName: Defaults[.gitRepositoryUsername]!,
-                    password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase")!,
+                    password: Utils.getPasswordFromKeychain(name: "gitRepositorySSHPrivateKeyPassphrase") ?? "",
                     publicKeyFile: Globals.sshPublicKeyURL,
                     privateKeyFile: Globals.sshPrivateKeyURL,
                     passwordNotSetCallback: nil


### PR DESCRIPTION
PR #31 introduced a bug, that cause the app to crash, when the ssh key is `nil`. I am not yet used to working with optionals :)