### PR TITLE
Move repository to a private directory

### DIFF
--- a/pass/Helpers/Globals.swift
+++ b/pass/Helpers/Globals.swift
@@ -11,13 +11,14 @@ import UIKit
 
 class Globals {
     static let documentPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0];
+    static let libraryPath = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)[0];
     static let pgpPublicKeyPath = "\(documentPath)/gpg_key.pub"
     static let pgpPrivateKeyPath = "\(documentPath)/gpg_key"
 
     static let sshPublicKeyURL = URL(fileURLWithPath: "\(documentPath)/ssh_key.pub")
     static let sshPrivateKeyURL = URL(fileURLWithPath: "\(documentPath)/ssh_key")
     
-    static let repositoryPath = "\(documentPath)/password-store"
+    static let repositoryPath = "\(libraryPath)/password-store"
     static var passcodeConfiguration = PasscodeLockConfiguration()
     static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
     

--- a/pass/Models/PasswordStore.swift
+++ b/pass/Models/PasswordStore.swift
@@ -96,8 +96,8 @@ struct GitCredential {
 class PasswordStore {
     static let shared = PasswordStore()
     
-    let storeURL = URL(fileURLWithPath: "\(Globals.documentPath)/password-store")
-    let tempStoreURL = URL(fileURLWithPath: "\(Globals.documentPath)/password-store-temp")
+    let storeURL = URL(fileURLWithPath: "\(Globals.repositoryPath)")
+    let tempStoreURL = URL(fileURLWithPath: "\(Globals.repositoryPath)-temp")
     var storeRepository: GTRepository?
     var gitCredential: GitCredential?
     


### PR DESCRIPTION
This is related to #22.
It is required to clone the repository once again after this change. I did not find any easy way to do so unfortunately. I had to first switch to another repository, and then switch back in order to do so. 
Is this a concern on such an early development stage?