### PR TITLE
Fix commit log view nil error

### DIFF
--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -415,8 +415,9 @@ public class PasswordStore {
             try enumerator.pushSHA(targetOID.sha)
         }
         for _ in 0 ..< count {
-            let commit = try enumerator.nextObject(withSuccess: nil)
-            commits.append(commit)
+            if let commit = try? enumerator.nextObject(withSuccess: nil) {
+                commits.append(commit)
+            }
         }
         return commits
     }


### PR DESCRIPTION
Fix the `Foundation._GenericObjCError.NilError` on commit log view.

![image](https://user-images.githubusercontent.com/1680515/46783160-d12e7180-cd5b-11e8-9bb1-0a53788606a1.png)
