### PR TITLE
Separate OTP token creation

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		18F19A67B0C07F13C17169E0 /* Pods_pass.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5620D17DF5E86B61761D0E /* Pods_pass.framework */; };
 		23B82F0228254275DBA609E7 /* Pods_passExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B975797E0F0B7476CADD6A7D /* Pods_passExtension.framework */; };
 		301F6463216162550071A4CE /* AdditionField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6462216162550071A4CE /* AdditionField.swift */; };
-		301F6466216164830071A4CE /* PasswordHelpersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6465216164830071A4CE /* PasswordHelpersTest.swift */; };
 		301F6468216165290071A4CE /* ConstantsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6467216165290071A4CE /* ConstantsTest.swift */; };
 		301F646A216166000071A4CE /* StringExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6469216166000071A4CE /* StringExtensionTest.swift */; };
 		301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F646C216166AA0071A4CE /* AdditionFieldTest.swift */; };
@@ -18,7 +17,9 @@
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
 		30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */; };
 		30A1D29E21AF468F00E2D1F7 /* PasswordGeneratorFlavour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */; };
-		30AAC05321989DCE00F656CE /* PasswordHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AAC05221989DCE00F656CE /* PasswordHelpers.swift */; };
+		30A1D2A621B2D46100E2D1F7 /* OtpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A521B2D46100E2D1F7 /* OtpType.swift */; };
+		30A1D2A821B2D53200E2D1F7 /* PasswordChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */; };
+		30A1D2AA21B32A0100E2D1F7 /* OtpTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */; };
 		30B04860209A5141001013CA /* PasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B0485F209A5141001013CA /* PasswordTest.swift */; };
 		30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FD2F77214D9E0E005E0A92 /* ParserTest.swift */; };
 		61326CDA7A73757FB68DCB04 /* Pods_passKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAB3F5541E51ADC8C6B56642 /* Pods_passKit.framework */; };
@@ -186,7 +187,6 @@
 
 /* Begin PBXFileReference section */
 		301F6462216162550071A4CE /* AdditionField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionField.swift; sourceTree = "<group>"; };
-		301F6465216164830071A4CE /* PasswordHelpersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordHelpersTest.swift; sourceTree = "<group>"; };
 		301F6467216165290071A4CE /* ConstantsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTest.swift; sourceTree = "<group>"; };
 		301F6469216166000071A4CE /* StringExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTest.swift; sourceTree = "<group>"; };
 		301F646C216166AA0071A4CE /* AdditionFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionFieldTest.swift; sourceTree = "<group>"; };
@@ -194,7 +194,9 @@
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorFlavourTest.swift; sourceTree = "<group>"; };
 		30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordGeneratorFlavour.swift; path = Helpers/PasswordGeneratorFlavour.swift; sourceTree = "<group>"; };
-		30AAC05221989DCE00F656CE /* PasswordHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordHelpers.swift; path = Helpers/PasswordHelpers.swift; sourceTree = "<group>"; };
+		30A1D2A521B2D46100E2D1F7 /* OtpType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtpType.swift; sourceTree = "<group>"; };
+		30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordChange.swift; sourceTree = "<group>"; };
+		30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtpTypeTest.swift; sourceTree = "<group>"; };
 		30B0485F209A5141001013CA /* PasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTest.swift; sourceTree = "<group>"; };
 		30FD2F77214D9E0E005E0A92 /* ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTest.swift; sourceTree = "<group>"; };
 		31C3033E8868D05B2C55C8B1 /* Pods-passExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-passExtension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-passExtension/Pods-passExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -384,7 +386,6 @@
 		301F6464216164670071A4CE /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				301F6465216164830071A4CE /* PasswordHelpersTest.swift */,
 				301F6469216166000071A4CE /* StringExtensionTest.swift */,
 				30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */,
 			);
@@ -396,7 +397,9 @@
 			children = (
 				301F6462216162550071A4CE /* AdditionField.swift */,
 				302E85622125EE550031BA64 /* Constants.swift */,
+				30A1D2A521B2D46100E2D1F7 /* OtpType.swift */,
 				302E85602125ECC70031BA64 /* Parser.swift */,
+				30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */,
 			);
 			path = Parser;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 			children = (
 				301F646C216166AA0071A4CE /* AdditionFieldTest.swift */,
 				301F6467216165290071A4CE /* ConstantsTest.swift */,
+				30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */,
 				30FD2F77214D9E0E005E0A92 /* ParserTest.swift */,
 			);
 			path = Parser;
@@ -534,7 +538,6 @@
 				A2F4E21A1EED80160011986E /* Globals.swift */,
 				A2F4E21B1EED80160011986E /* NotificationNames.swift */,
 				30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */,
-				30AAC05221989DCE00F656CE /* PasswordHelpers.swift */,
 				A239F51E2157B72700576CBF /* StringExtension.swift */,
 				A2F4E21C1EED80160011986E /* UITextFieldExtension.swift */,
 				A2BEC1BA207D2EFE00F3051C /* UIViewExtension.swift */,
@@ -1156,6 +1159,7 @@
 				A2F4E2151EED800F0011986E /* Password.swift in Sources */,
 				A26075AD1EEC7125005DB03E /* pass.xcdatamodeld in Sources */,
 				30A1D29E21AF468F00E2D1F7 /* PasswordGeneratorFlavour.swift in Sources */,
+				30A1D2A821B2D53200E2D1F7 /* PasswordChange.swift in Sources */,
 				A239F51F2157B72700576CBF /* StringExtension.swift in Sources */,
 				A239F5212157B75E00576CBF /* FileManagerExtension.swift in Sources */,
 				A2F4E21E1EED80160011986E /* AppError.swift in Sources */,
@@ -1165,10 +1169,10 @@
 				A2F4E2221EED80160011986E /* UITextFieldExtension.swift in Sources */,
 				A2C532BF201E5AA100DB9F53 /* PasscodeLockPresenter.swift in Sources */,
 				A2C532BE201E5AA100DB9F53 /* PasscodeLockViewController.swift in Sources */,
-				30AAC05321989DCE00F656CE /* PasswordHelpers.swift in Sources */,
 				A2F4E2201EED80160011986E /* Globals.swift in Sources */,
 				A2F4E2231EED80160011986E /* Utils.swift in Sources */,
 				A2F4E21F1EED80160011986E /* DefaultsKeys.swift in Sources */,
+				30A1D2A621B2D46100E2D1F7 /* OtpType.swift in Sources */,
 				A2F4E2141EED800F0011986E /* GitCredential.swift in Sources */,
 				A2F4E2161EED800F0011986E /* PasswordEntity.swift in Sources */,
 			);
@@ -1179,10 +1183,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				301F646A216166000071A4CE /* StringExtensionTest.swift in Sources */,
-				301F6466216164830071A4CE /* PasswordHelpersTest.swift in Sources */,
 				301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */,
 				30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */,
 				30B04860209A5141001013CA /* PasswordTest.swift in Sources */,
+				30A1D2AA21B32A0100E2D1F7 /* OtpTypeTest.swift in Sources */,
 				301F6468216165290071A4CE /* ConstantsTest.swift in Sources */,
 				30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */,
 				A26075881EEC6F34005DB03E /* passKitTests.swift in Sources */,

--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -17,9 +17,11 @@
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
 		30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */; };
 		30A1D29E21AF468F00E2D1F7 /* PasswordGeneratorFlavour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */; };
+		30A1D2A221B2BC6F00E2D1F7 /* TokenBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A121B2BC6F00E2D1F7 /* TokenBuilder.swift */; };
 		30A1D2A621B2D46100E2D1F7 /* OtpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A521B2D46100E2D1F7 /* OtpType.swift */; };
 		30A1D2A821B2D53200E2D1F7 /* PasswordChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */; };
 		30A1D2AA21B32A0100E2D1F7 /* OtpTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */; };
+		30A1D2AC21B32C2A00E2D1F7 /* TokenBuilderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D2AB21B32C2A00E2D1F7 /* TokenBuilderTest.swift */; };
 		30B04860209A5141001013CA /* PasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B0485F209A5141001013CA /* PasswordTest.swift */; };
 		30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FD2F77214D9E0E005E0A92 /* ParserTest.swift */; };
 		61326CDA7A73757FB68DCB04 /* Pods_passKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAB3F5541E51ADC8C6B56642 /* Pods_passKit.framework */; };
@@ -194,9 +196,11 @@
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorFlavourTest.swift; sourceTree = "<group>"; };
 		30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordGeneratorFlavour.swift; path = Helpers/PasswordGeneratorFlavour.swift; sourceTree = "<group>"; };
+		30A1D2A121B2BC6F00E2D1F7 /* TokenBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenBuilder.swift; sourceTree = "<group>"; };
 		30A1D2A521B2D46100E2D1F7 /* OtpType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtpType.swift; sourceTree = "<group>"; };
 		30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordChange.swift; sourceTree = "<group>"; };
 		30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtpTypeTest.swift; sourceTree = "<group>"; };
+		30A1D2AB21B32C2A00E2D1F7 /* TokenBuilderTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenBuilderTest.swift; sourceTree = "<group>"; };
 		30B0485F209A5141001013CA /* PasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTest.swift; sourceTree = "<group>"; };
 		30FD2F77214D9E0E005E0A92 /* ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTest.swift; sourceTree = "<group>"; };
 		31C3033E8868D05B2C55C8B1 /* Pods-passExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-passExtension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-passExtension/Pods-passExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -400,6 +404,7 @@
 				30A1D2A521B2D46100E2D1F7 /* OtpType.swift */,
 				302E85602125ECC70031BA64 /* Parser.swift */,
 				30A1D2A721B2D53200E2D1F7 /* PasswordChange.swift */,
+				30A1D2A121B2BC6F00E2D1F7 /* TokenBuilder.swift */,
 			);
 			path = Parser;
 			sourceTree = "<group>";
@@ -411,6 +416,7 @@
 				301F6467216165290071A4CE /* ConstantsTest.swift */,
 				30A1D2A921B32A0100E2D1F7 /* OtpTypeTest.swift */,
 				30FD2F77214D9E0E005E0A92 /* ParserTest.swift */,
+				30A1D2AB21B32C2A00E2D1F7 /* TokenBuilderTest.swift */,
 			);
 			path = Parser;
 			sourceTree = "<group>";
@@ -1152,6 +1158,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				30A1D2A221B2BC6F00E2D1F7 /* TokenBuilder.swift in Sources */,
 				A2BEC1BB207D2EFE00F3051C /* UIViewExtension.swift in Sources */,
 				302E85632125EE550031BA64 /* Constants.swift in Sources */,
 				301F6463216162550071A4CE /* AdditionField.swift in Sources */,
@@ -1183,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				301F646A216166000071A4CE /* StringExtensionTest.swift in Sources */,
+				30A1D2AC21B32C2A00E2D1F7 /* TokenBuilderTest.swift in Sources */,
 				301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */,
 				30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */,
 				30B04860209A5141001013CA /* PasswordTest.swift in Sources */,

--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F646C216166AA0071A4CE /* AdditionFieldTest.swift */; };
 		302E85612125ECC70031BA64 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85602125ECC70031BA64 /* Parser.swift */; };
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
+		30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */; };
+		30A1D29E21AF468F00E2D1F7 /* PasswordGeneratorFlavour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */; };
 		30AAC05321989DCE00F656CE /* PasswordHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AAC05221989DCE00F656CE /* PasswordHelpers.swift */; };
 		30B04860209A5141001013CA /* PasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B0485F209A5141001013CA /* PasswordTest.swift */; };
 		30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FD2F77214D9E0E005E0A92 /* ParserTest.swift */; };
@@ -190,6 +192,8 @@
 		301F646C216166AA0071A4CE /* AdditionFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionFieldTest.swift; sourceTree = "<group>"; };
 		302E85602125ECC70031BA64 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordGeneratorFlavourTest.swift; sourceTree = "<group>"; };
+		30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordGeneratorFlavour.swift; path = Helpers/PasswordGeneratorFlavour.swift; sourceTree = "<group>"; };
 		30AAC05221989DCE00F656CE /* PasswordHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordHelpers.swift; path = Helpers/PasswordHelpers.swift; sourceTree = "<group>"; };
 		30B0485F209A5141001013CA /* PasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTest.swift; sourceTree = "<group>"; };
 		30FD2F77214D9E0E005E0A92 /* ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTest.swift; sourceTree = "<group>"; };
@@ -382,6 +386,7 @@
 			children = (
 				301F6465216164830071A4CE /* PasswordHelpersTest.swift */,
 				301F6469216166000071A4CE /* StringExtensionTest.swift */,
+				30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -528,6 +533,7 @@
 				A239F5202157B75E00576CBF /* FileManagerExtension.swift */,
 				A2F4E21A1EED80160011986E /* Globals.swift */,
 				A2F4E21B1EED80160011986E /* NotificationNames.swift */,
+				30A1D29D21AF468E00E2D1F7 /* PasswordGeneratorFlavour.swift */,
 				30AAC05221989DCE00F656CE /* PasswordHelpers.swift */,
 				A239F51E2157B72700576CBF /* StringExtension.swift */,
 				A2F4E21C1EED80160011986E /* UITextFieldExtension.swift */,
@@ -1149,6 +1155,7 @@
 				A2C532BB201E5A9600DB9F53 /* PasscodeLock.swift in Sources */,
 				A2F4E2151EED800F0011986E /* Password.swift in Sources */,
 				A26075AD1EEC7125005DB03E /* pass.xcdatamodeld in Sources */,
+				30A1D29E21AF468F00E2D1F7 /* PasswordGeneratorFlavour.swift in Sources */,
 				A239F51F2157B72700576CBF /* StringExtension.swift in Sources */,
 				A239F5212157B75E00576CBF /* FileManagerExtension.swift in Sources */,
 				A2F4E21E1EED80160011986E /* AppError.swift in Sources */,
@@ -1177,6 +1184,7 @@
 				30FD2F78214D9E0E005E0A92 /* ParserTest.swift in Sources */,
 				30B04860209A5141001013CA /* PasswordTest.swift in Sources */,
 				301F6468216165290071A4CE /* ConstantsTest.swift in Sources */,
+				30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */,
 				A26075881EEC6F34005DB03E /* passKitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/pass/AppDelegate.swift
+++ b/pass/AppDelegate.swift
@@ -33,7 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 self.perform(#selector(postSearchNotification), with: nil, afterDelay: 0.4)
             }
         }
-        Utils.initDefaultKeys()
         return true
     }
     

--- a/pass/Controllers/AddPasswordTableViewController.swift
+++ b/pass/Controllers/AddPasswordTableViewController.swift
@@ -20,8 +20,7 @@ class AddPasswordTableViewController: PasswordEditorTableViewController {
             [[.type: PasswordEditorCellType.additionsCell, .title: "additions"]],
             [[.type: PasswordEditorCellType.scanQRCodeCell]]
         ]
-        if let lengthSetting = Globals.passwordDefaultLength[SharedDefaults[.passwordGeneratorFlavor]],
-            lengthSetting.max > lengthSetting.min {
+        if PasswordGeneratorFlavour.from(SharedDefaults[.passwordGeneratorFlavor]) == PasswordGeneratorFlavour.RANDOM {
             tableData[1].append([.type: PasswordEditorCellType.passwordLengthCell, .title: "passwordlength"])
         }
         tableData[1].append([.type: PasswordEditorCellType.memorablePasswordGeneratorCell])

--- a/pass/Controllers/EditPasswordTableViewController.swift
+++ b/pass/Controllers/EditPasswordTableViewController.swift
@@ -18,8 +18,7 @@ class EditPasswordTableViewController: PasswordEditorTableViewController {
             [[.type: PasswordEditorCellType.scanQRCodeCell],
              [.type: PasswordEditorCellType.deletePasswordCell]]
         ]
-        if let lengthSetting = Globals.passwordDefaultLength[SharedDefaults[.passwordGeneratorFlavor]],
-            lengthSetting.max > lengthSetting.min {
+        if PasswordGeneratorFlavour.from(SharedDefaults[.passwordGeneratorFlavor]) == PasswordGeneratorFlavour.RANDOM {
             tableData[1].append([.type: PasswordEditorCellType.passwordLengthCell, .title: "passwordlength"])
         }
         tableData[1].append([.type: PasswordEditorCellType.memorablePasswordGeneratorCell])

--- a/pass/Controllers/PasswordEditorTableViewController.swift
+++ b/pass/Controllers/PasswordEditorTableViewController.swift
@@ -104,11 +104,10 @@ class PasswordEditorTableViewController: UITableViewController, FillPasswordTabl
             return fillPasswordCell!
         case .passwordLengthCell:
             passwordLengthCell = tableView.dequeueReusableCell(withIdentifier: "passwordLengthCell", for: indexPath) as? SliderTableViewCell
-            let lengthSetting = Globals.passwordDefaultLength[SharedDefaults[.passwordGeneratorFlavor]] ??
-                Globals.passwordDefaultLength["Random"]
-            let minimumLength = lengthSetting?.min ?? 0
-            let maximumLength = lengthSetting?.max ?? 0
-            var defaultLength = lengthSetting?.def ?? 0
+            let lengthSetting = PasswordGeneratorFlavour.from(SharedDefaults[.passwordGeneratorFlavor]).defaultLength
+            let minimumLength = lengthSetting.min
+            let maximumLength = lengthSetting.max
+            var defaultLength = lengthSetting.def
             if let currentPasswordLength = (tableData[passwordSection][0][PasswordEditorCellKey.content] as? String)?.count,
                 currentPasswordLength >= minimumLength,
                 currentPasswordLength <= maximumLength {
@@ -203,7 +202,7 @@ class PasswordEditorTableViewController: UITableViewController, FillPasswordTabl
         showPasswordSettings()
         
         let length = passwordLengthCell?.roundedValue ?? 0
-        let plainPassword = Password.generatePassword(length: length)
+        let plainPassword = PasswordGeneratorFlavour.from(SharedDefaults[.passwordGeneratorFlavor]).generatePassword(length: length)
         SecurePasteboard.shared.copy(textToCopy: plainPassword)
         
         // update tableData so to make sure reloadData() works correctly

--- a/passExtension/ExtensionViewController.swift
+++ b/passExtension/ExtensionViewController.swift
@@ -172,7 +172,7 @@ class ExtensionViewController: UIViewController, UITableViewDataSource, UITableV
                         let extensionItem = NSExtensionItem()
                         var returnDictionary = [OnePasswordExtensionKey.usernameKey: username,
                                                 OnePasswordExtensionKey.passwordKey: password]
-                        if let totpPassword = decryptedPassword?.getOtp() {
+                        if let totpPassword = decryptedPassword?.currentOtp {
                             returnDictionary[OnePasswordExtensionKey.totpKey] = totpPassword
                         }
                         extensionItem.attachments = [NSItemProvider(item: returnDictionary as NSSecureCoding, typeIdentifier: String(kUTTypePropertyList))]

--- a/passKit/Helpers/AppError.swift
+++ b/passKit/Helpers/AppError.swift
@@ -16,7 +16,6 @@ public enum AppError: Error {
     case GitResetError
     case PGPPublicKeyNotExistError
     case WrongPasswordFilename
-    case YamlLoadError
     case DecryptionError
     case UnknownError
 }
@@ -38,8 +37,6 @@ extension AppError: LocalizedError {
             return "PGP public key doesn't exist."
         case .WrongPasswordFilename:
             return "Cannot write to the password file."
-        case .YamlLoadError:
-            return "Cannot be parsed as a YAML file."
         case .DecryptionError:
             return "Cannot decrypt password."
         case .UnknownError:

--- a/passKit/Helpers/Globals.swift
+++ b/passKit/Helpers/Globals.swift
@@ -39,9 +39,6 @@ public class Globals {
     public static let iTunesFileSharingPGPPrivate = iTunesFileSharingPath + "/gpg_key"
     public static let iTunesFileSharingSSHPrivate = iTunesFileSharingPath + "/ssh_key"
     
-    public static let passwordDefaultLength = ["Random": (min: 4, max: 64, def: 16),
-                                        "Apple":  (min: 15, max: 15, def: 15)]
-    
     public static let gitSignatureDefaultName = "Pass for iOS"
     public static let gitSignatureDefaultEmail = "user@passforios"
     

--- a/passKit/Helpers/PasswordGeneratorFlavour.swift
+++ b/passKit/Helpers/PasswordGeneratorFlavour.swift
@@ -1,0 +1,44 @@
+//
+//  PasswordGeneratorFlavour.swift
+//  passKit
+//
+//  Created by Danny Moesch on 28.11.18.
+//  Copyright © 2018 Bob Sun. All rights reserved.
+//
+
+import KeychainAccess
+
+public enum PasswordGeneratorFlavour: String {
+    case APPLE = "Apple"
+    case RANDOM = "Random"
+
+    private static let ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*_+-="
+
+    public static func from(_ option: String) -> PasswordGeneratorFlavour {
+        return PasswordGeneratorFlavour(rawValue: option) ?? PasswordGeneratorFlavour.RANDOM
+    }
+
+    public var defaultLength: (min: Int, max: Int, def: Int) {
+        switch self {
+        case .APPLE:
+            return (15, 15, 15)
+        default:
+            return (4, 64, 16)
+        }
+    }
+
+    public func generatePassword(length: Int) -> String {
+        switch self {
+        case .APPLE:
+            return Keychain.generatePassword()
+        default:
+            return PasswordGeneratorFlavour.randomString(length: length)
+        }
+    }
+
+    private static func randomString(length: Int) -> String {
+        return String((0..<length).map { _ in ALLOWED_CHARACTERS.randomElement()! })
+    }
+}
+
+extension PasswordGeneratorFlavour: CaseIterable {}

--- a/passKit/Helpers/Utils.swift
+++ b/passKit/Helpers/Utils.swift
@@ -53,11 +53,6 @@ public class Utils {
         }
         return attributedPassword
     }
-    public static func initDefaultKeys() {
-        if SharedDefaults[.passwordGeneratorFlavor] == "" {
-            SharedDefaults[.passwordGeneratorFlavor] = "Random"
-        }
-    }
     
     public static func alert(title: String, message: String, controller: UIViewController, handler: ((UIAlertAction) -> Void)? = nil, completion: (() -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -156,7 +156,7 @@ public class Password {
         }
         
         // get secret data
-        guard let secretString = getAdditionValue(withKey: "otp_secret"),
+        guard let secretString = getAdditionValue(withKey: Constants.OTP_SECRET),
             let secretData = MF_Base32Codec.data(fromBase32String: secretString),
             !secretData.isEmpty else {
                 // Missing / Invalid otp secret
@@ -164,19 +164,19 @@ public class Password {
         }
         
         // get type
-        guard let type = getAdditionValue(withKey: "otp_type")?.lowercased(),
-            (type == "totp" || type == "hotp") else {
-                // Missing / Invalid otp type
+        guard let type = getAdditionValue(withKey: Constants.OTP_TYPE)?.lowercased(),
+            (type == Constants.TOTP || type == Constants.HOTP) else {
+                // Missing/Invalid OTP type
                 return
         }
         
         // get algorithm (optional)
         var algorithm = Generator.Algorithm.sha1
-        if let algoString = getAdditionValue(withKey: "otp_algorithm") {
+        if let algoString = getAdditionValue(withKey: Constants.OTP_ALGORITHM) {
             switch algoString.lowercased() {
-                case "sha256":
+                case Constants.SHA256:
                     algorithm = .sha256
-                case "sha512":
+                case Constants.SHA512:
                     algorithm = .sha512
                 default:
                     algorithm = .sha1
@@ -184,12 +184,12 @@ public class Password {
         }
     
         // construct the token
-        if type == "totp" {
+        if type == Constants.TOTP {
             // HOTP
             // default: 6 digits, 30 seconds
-            guard let digits = Int(getAdditionValue(withKey: "otp_digits") ?? "6"),
-                let period = Double(getAdditionValue(withKey: "otp_period") ?? "30.0") else {
-                    // Invalid otp_digits or otp_period.
+            guard let digits = Int(getAdditionValue(withKey: Constants.OTP_DIGITS) ?? Constants.DEFAULT_DIGITS),
+                let period = Double(getAdditionValue(withKey: Constants.OTP_PERIOD) ?? Constants.DEFAULT_PERIOD) else {
+                    // Invalid OTP digits or OTP period.
                     return
             }
             guard let generator = Generator(
@@ -204,9 +204,9 @@ public class Password {
         } else {
             // HOTP
             // default: 6 digits
-            guard let digits = Int(getAdditionValue(withKey: "otp_digits") ?? "6"),
-                let counter = UInt64(getAdditionValue(withKey: "otp_counter") ?? "") else {
-                    // Invalid otp_digits or otp_counter.
+            guard let digits = Int(getAdditionValue(withKey: Constants.OTP_DIGITS) ?? Constants.DEFAULT_DIGITS),
+                let counter = UInt64(getAdditionValue(withKey: Constants.OTP_COUNTER) ?? Constants.DEFAULT_COUNTER) else {
+                    // Invalid OTP digits or OTP counter.
                     return
             }
             guard let generator = Generator(

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2017 Bob Sun. All rights reserved.
 //
 
-import SwiftyUserDefaults
 import OneTimePassword
 import Base32
 
@@ -56,6 +55,10 @@ public class Password {
         return getAdditionValue(withKey: Constants.URL_KEYWORD)
     }
 
+    public var currentOtp: String? {
+        return otpToken?.currentPassword
+    }
+
     public init(name: String, url: URL, plainText: String) {
         self.name = name
         self.url = url
@@ -83,7 +86,7 @@ public class Password {
     }
 
     private func initEverything() {
-        parser = Parser(plainText: self.plainText)
+        parser = Parser(plainText: plainText)
         additions = parser.additionFields
 
         // Check whether the first line looks like an otp entry.
@@ -95,9 +98,9 @@ public class Password {
 
     private func checkPasswordForOtpToken() {
         let (key, value) = Parser.getKeyValuePair(from: password)
-        if Constants.OTP_KEYWORDS.contains(key ?? "") {
+        if let key = key, Constants.OTP_KEYWORDS.contains(key) {
             firstLineIsOTPField = true
-            additions.append(key! => value)
+            additions.append(key => value)
         } else {
             firstLineIsOTPField = false
         }
@@ -114,7 +117,7 @@ public class Password {
     }
 
     private func getAdditionValue(withKey key: String, caseSensitive: Bool = false) -> String? {
-        let toLowercase = { (string: String) -> String in return caseSensitive ? string : string.lowercased() }
+        let toLowercase = { (string: String) -> String in caseSensitive ? string : string.lowercased() }
         return additions.first(where: { toLowercase($0.title) == toLowercase(key) })?.content
     }
     
@@ -238,11 +241,6 @@ public class Password {
         }
         let otp = self.otpToken?.currentPassword ?? "error"
         return (description, otp)
-    }
-    
-    // return the password strings
-    public func getOtp() -> String? {
-        return self.otpToken?.currentPassword
     }
     
     // return the password strings

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -121,29 +121,19 @@ public class Password {
         return additions.first(where: { toLowercase($0.title) == toLowercase(key) })?.content
     }
     
-    /*
-     Set otpType and otpToken, if we are able to construct a valid token.
-     
-     Example of TOTP otpauth
-     (Key Uri Format: https://github.com/google/google-authenticator/wiki/Key-Uri-Format)
-     otpauth://totp/totp-secret?secret=AAAAAAAAAAAAAAAA&issuer=totp-secret
-     
-     Example of TOTP fields [Legacy, lower priority]
-     otp_secret: secretsecretsecretsecretsecretsecret
-     otp_type: totp
-     otp_algorithm: sha1 (default: sha1, optional)
-     otp_period: 30 (default: 30, optional)
-     otp_digits: 6 (default: 6, optional)
-     
-     Example of HOTP fields [Legacy, lower priority]
-     otp_secret: secretsecretsecretsecretsecretsecret
-     otp_type: hotp
-     otp_counter: 1
-     otp_digits: 6 (default: 6, optional)
-     
-     */
+    /// Set the OTP token if we are able to construct a valid one.
+    ///
+    /// Example of TOTP otpauth:
+    ///
+    ///     otpauth://totp/totp-secret?secret=AAAAAAAAAAAAAAAA&issuer=totp-secret
+    ///
+    /// See also [Key Uri Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
+    ///
+    /// In case no otpauth is given in the password file, try to construct the token from separate fields using a
+    /// `TokenBuilder`. This means that tokens provided as otpauth have higher priority.
+    ///
     private func updateOtpToken() {
-        // get otpauth, if we are able to generate a token, return
+        // Get otpauth. If we are able to generate a token, return.
         if var otpauthString = getAdditionValue(withKey: Constants.OTPAUTH, caseSensitive: true) {
             if !otpauthString.hasPrefix("\(Constants.OTPAUTH):") {
                 otpauthString = "\(Constants.OTPAUTH):\(otpauthString)"
@@ -153,7 +143,8 @@ public class Password {
                 return
             }
         }
-        
+
+        // Construct OTP token from separate fields provided in the password file.
         otpToken = TokenBuilder()
             .usingName(name)
             .usingSecret(getAdditionValue(withKey: Constants.OTP_SECRET))

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -108,11 +108,12 @@ public class Password {
 
     public func getFilteredAdditions() -> [AdditionField] {
         return additions.filter { field in
-            field.title.lowercased() != Constants.USERNAME_KEYWORD
-            && field.title.lowercased() != Constants.LOGIN_KEYWORD
-            && field.title.lowercased() != Constants.PASSWORD_KEYWORD
-            && (!field.title.hasPrefix(Constants.UNKNOWN) || !SharedDefaults[.isHideUnknownOn])
-            && (!Constants.OTP_KEYWORDS.contains(field.title) || !SharedDefaults[.isHideOTPOn])
+            let title = field.title.lowercased()
+            return title != Constants.USERNAME_KEYWORD
+                && title != Constants.LOGIN_KEYWORD
+                && title != Constants.PASSWORD_KEYWORD
+                && (!field.title.hasPrefix(Constants.UNKNOWN) || !SharedDefaults[.isHideUnknownOn])
+                && (!Constants.OTP_KEYWORDS.contains(title) || !SharedDefaults[.isHideOTPOn])
         }
     }
 

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -9,7 +9,6 @@
 import SwiftyUserDefaults
 import OneTimePassword
 import Base32
-import KeychainAccess
 
 public class Password {
     
@@ -275,32 +274,5 @@ public class Password {
         
         // get and return the password
         return self.otpToken?.currentPassword
-    }
-    
-    public static func generatePassword(length: Int) -> String{
-        switch SharedDefaults[.passwordGeneratorFlavor] {
-        case "Random":
-            return randomString(length: length)
-        case "Apple":
-            return Keychain.generatePassword()
-        default:
-            return randomString(length: length)
-        }
-    }
-    
-    private static func randomString(length: Int) -> String {
-        
-        let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*_+-="
-        let len = UInt32(letters.length)
-        
-        var randomString = ""
-        
-        for _ in 0 ..< length {
-            let rand = arc4random_uniform(len)
-            var nextChar = letters.character(at: Int(rand))
-            randomString += NSString(characters: &nextChar, length: 1) as String
-        }
-        
-        return randomString
     }
 }

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -156,24 +156,18 @@ public class Password {
             .build()
     }
     
-    // return the description and the password strings
+    /// Get the OTP description and the current password.
     public func getOtpStrings() -> (description: String, otp: String)? {
-        guard let token = self.otpToken else {
+        guard otpToken != nil else {
             return nil
         }
-        var description : String
-        switch token.generator.factor {
-        case .counter:
-            // htop
-            description = "HMAC-based"
-        case .timer(let period):
-            // totp
+        var description = otpType.description
+        if case let .timer(period)? = otpToken?.generator.factor {
             let timeSinceEpoch = Date().timeIntervalSince1970
             let validTime = Int(period - timeSinceEpoch.truncatingRemainder(dividingBy: period))
-            description = "time-based (expiring in \(validTime)s)"
+            description += " (expires in \(validTime)s)"
         }
-        let otp = self.otpToken?.currentPassword ?? "error"
-        return (description, otp)
+        return (description, otpToken!.currentPassword ?? "error")
     }
     
     // return the password strings

--- a/passKit/Parser/Constants.swift
+++ b/passKit/Parser/Constants.swift
@@ -30,9 +30,9 @@ public struct Constants {
     static let HOTP = "hotp"
     static let SHA256 = "sha256"
     static let SHA512 = "sha512"
-    static let DEFAULT_DIGITS = "6"
-    static let DEFAULT_PERIOD = "30.0"
-    static let DEFAULT_COUNTER = ""
+    static let DEFAULT_DIGITS = 6
+    static let DEFAULT_PERIOD = 30.0
+    static let DEFAULT_COUNTER: UInt64? = nil
 
     static let BLANK = " "
     static let MULTILINE_WITH_LINE_BREAK_INDICATOR = "|"

--- a/passKit/Parser/Constants.swift
+++ b/passKit/Parser/Constants.swift
@@ -8,15 +8,31 @@
 
 public struct Constants {
 
+    static let OTP_SECRET = "otp_secret"
+    static let OTP_TYPE = "otp_type"
+    static let OTP_ALGORITHM = "otp_algorithm"
+    static let OTP_PERIOD = "otp_period"
+    static let OTP_DIGITS = "otp_digits"
+    static let OTP_COUNTER = "otp_counter"
+    static let OTPAUTH = "otpauth"
+
     public static let OTP_KEYWORDS = [
-        "otp_secret",
-        "otp_type",
-        "otp_algorithm",
-        "otp_period",
-        "otp_digits",
-        "otp_counter",
-        "otpauth",
+        OTP_SECRET,
+        OTP_TYPE,
+        OTP_ALGORITHM,
+        OTP_PERIOD,
+        OTP_DIGITS,
+        OTP_COUNTER,
+        OTPAUTH,
     ]
+
+    static let TOTP = "totp"
+    static let HOTP = "hotp"
+    static let SHA256 = "sha256"
+    static let SHA512 = "sha512"
+    static let DEFAULT_DIGITS = "6"
+    static let DEFAULT_PERIOD = "30.0"
+    static let DEFAULT_COUNTER = ""
 
     static let BLANK = " "
     static let MULTILINE_WITH_LINE_BREAK_INDICATOR = "|"
@@ -24,7 +40,6 @@ public struct Constants {
     static let MULTILINE_WITHOUT_LINE_BREAK_INDICATOR = ">"
     static let MULTILINE_WITHOUT_LINE_BREAK_SEPARATOR = BLANK
 
-    static let OTPAUTH = "otpauth"
     static let OTPAUTH_URL_START = "\(OTPAUTH)://"
     static let PASSWORD_KEYWORD = "password"
     static let USERNAME_KEYWORD = "username"

--- a/passKit/Parser/OtpType.swift
+++ b/passKit/Parser/OtpType.swift
@@ -8,9 +8,15 @@
 
 import OneTimePassword
 
-public enum OtpType {
-    case totp, hotp, none
+public enum OtpType: String {
+    case totp = "time-based"
+    case hotp = "HMAC-based"
+    case none
 
+    var description: String {
+        return rawValue
+    }
+    
     init(token: Token?) {
         switch token?.generator.factor {
         case .some(.counter):

--- a/passKit/Parser/OtpType.swift
+++ b/passKit/Parser/OtpType.swift
@@ -1,8 +1,8 @@
 //
-//  PasswordHelpers.swift
+//  OtpType.swift
 //  passKit
 //
-//  Created by Danny Moesch on 17.08.18.
+//  Created by Danny Moesch on 01.12.2018.
 //  Copyright © 2018 Bob Sun. All rights reserved.
 //
 
@@ -10,7 +10,7 @@ import OneTimePassword
 
 public enum OtpType {
     case totp, hotp, none
-    
+
     init(token: Token?) {
         switch token?.generator.factor {
         case .some(.counter):
@@ -21,10 +21,15 @@ public enum OtpType {
             self = .none
         }
     }
-}
 
-enum PasswordChange: Int {
-    case path = 0x01
-    case content = 0x02
-    case none = 0x00
+    init(name: String?) {
+        switch name?.lowercased() {
+        case Constants.HOTP:
+            self = .hotp
+        case Constants.TOTP:
+            self = .totp
+        default:
+            self = .none
+        }
+    }
 }

--- a/passKit/Parser/PasswordChange.swift
+++ b/passKit/Parser/PasswordChange.swift
@@ -1,0 +1,13 @@
+//
+//  PasswordChange.swift
+//  passKit
+//
+//  Created by Danny Moesch on 01.12.2018.
+//  Copyright © 2018 Bob Sun. All rights reserved.
+//
+
+enum PasswordChange: Int {
+    case path = 0x01
+    case content = 0x02
+    case none = 0x00
+}

--- a/passKit/Parser/TokenBuilder.swift
+++ b/passKit/Parser/TokenBuilder.swift
@@ -1,0 +1,88 @@
+//
+//  TokenBuilder.swift
+//  passKit
+//
+//  Created by Danny Moesch on 01.12.18.
+//  Copyright © 2018 Bob Sun. All rights reserved.
+//
+
+import Base32
+import OneTimePassword
+
+class TokenBuilder {
+
+    private var name: String = ""
+    private var secret: Data?
+    private var type: OtpType = .totp
+    private var algorithm: Generator.Algorithm = .sha1
+    private var digits: Int? = Constants.DEFAULT_DIGITS
+    private var period: Double? = Constants.DEFAULT_PERIOD
+    private var counter: UInt64? = Constants.DEFAULT_COUNTER
+
+    func usingName(_ name: String) -> TokenBuilder {
+        self.name = name
+        return self
+    }
+
+    func usingSecret(_ secret: String?) -> TokenBuilder {
+        if secret != nil, let secretData = MF_Base32Codec.data(fromBase32String: secret!), !secretData.isEmpty {
+            self.secret = secretData
+        }
+        return self
+    }
+
+    func usingType(_ type: String?) -> TokenBuilder {
+        self.type = OtpType(name: type)
+        return self
+    }
+
+    func usingAlgorithm(_ algorithm: String?) -> TokenBuilder {
+        switch algorithm?.lowercased() {
+        case Constants.SHA256:
+            self.algorithm = .sha256
+        case Constants.SHA512:
+            self.algorithm = .sha512
+        default:
+            self.algorithm = .sha1
+        }
+        return self
+    }
+
+    func usingDigits(_ digits: String?) -> TokenBuilder {
+        self.digits = digits == nil ? nil : Int(digits!)
+        return self
+    }
+
+    func usingPeriod(_ period: String?) -> TokenBuilder {
+        self.period = period == nil ? nil : Double(period!)
+        return self
+    }
+
+    func usingCounter(_ counter: String?) -> TokenBuilder {
+        self.counter = counter == nil ? nil : UInt64(counter!)
+        return self
+    }
+
+
+    func build() -> Token? {
+        guard secret != nil, digits != nil else {
+            return nil
+        }
+
+        switch type {
+        case .totp:
+            return period == nil ? nil : createToken(factor: Generator.Factor.timer(period: period!))
+        case .hotp:
+            return counter == nil ? nil : createToken(factor: Generator.Factor.counter(counter!))
+        default:
+            return nil
+        }
+    }
+
+    private func createToken(factor: Generator.Factor) -> Token? {
+        guard let generator = Generator(factor: factor, secret: secret!, algorithm: algorithm, digits: digits!) else {
+            return nil
+        }
+        return Token(name: name, issuer: "", generator: generator)
+    }
+}

--- a/passKit/Parser/TokenBuilder.swift
+++ b/passKit/Parser/TokenBuilder.swift
@@ -9,6 +9,23 @@
 import Base32
 import OneTimePassword
 
+/// Help building an OTP token from given data.
+///
+/// There is currently support TOTP and HOTP tokens:
+///
+/// * Necessary TOTP data
+///   * secret: `secretsecretsecretsecretsecretsecret`
+///   * type: `totp`
+///   * algorithm: `sha1` (default: `sha1`, optional)
+///   * period: `30` (default: `30`, optional)
+///   * digits: `6` (default: `6`, optional)
+///
+/// * Necessary HOTP data
+///   * secret: `secretsecretsecretsecretsecretsecret`
+///   * type: `hotp`
+///   * counter: `1`
+///   * digits: `6` (default: `6`, optional)
+///
 class TokenBuilder {
 
     private var name: String = ""

--- a/passKitTests/Helpers/PasswordGeneratorFlavourTest.swift
+++ b/passKitTests/Helpers/PasswordGeneratorFlavourTest.swift
@@ -1,0 +1,43 @@
+//
+//  PasswordGeneratorFlavourTest.swift
+//  passKitTests
+//
+//  Created by Danny Moesch on 28.11.18.
+//  Copyright © 2018 Bob Sun. All rights reserved.
+//
+
+import KeychainAccess
+import XCTest
+
+@testable import passKit
+
+class PasswordGeneratorFlavourTest: XCTestCase {
+
+    private let KEYCHAIN_PASSWORD_LENGTH = Keychain.generatePassword().count
+
+    func testFrom() {
+        XCTAssertEqual(PasswordGeneratorFlavour.from("Apple"), PasswordGeneratorFlavour.APPLE)
+        XCTAssertEqual(PasswordGeneratorFlavour.from("Random"), PasswordGeneratorFlavour.RANDOM)
+        XCTAssertEqual(PasswordGeneratorFlavour.from("Something"), PasswordGeneratorFlavour.RANDOM)
+        XCTAssertEqual(PasswordGeneratorFlavour.from(""), PasswordGeneratorFlavour.RANDOM)
+    }
+
+    func testDefaultLength() {
+        // Ensure properly chosen default length values. So this check no longer needs to be performed in the code.
+        PasswordGeneratorFlavour.allCases.map { $0.defaultLength }.forEach { defaultLength in
+            XCTAssertLessThanOrEqual(defaultLength.min, defaultLength.max)
+            XCTAssertLessThanOrEqual(defaultLength.def, defaultLength.max)
+            XCTAssertGreaterThanOrEqual(defaultLength.def, defaultLength.min)
+        }
+    }
+
+    func testGeneratePassword() {
+        let apple = PasswordGeneratorFlavour.APPLE
+        let random = PasswordGeneratorFlavour.RANDOM
+
+        XCTAssertEqual(apple.generatePassword(length: 4).count, KEYCHAIN_PASSWORD_LENGTH)
+        XCTAssertEqual(random.generatePassword(length: 0).count, 0)
+        XCTAssertEqual(random.generatePassword(length: 4).count, 4)
+        XCTAssertEqual(random.generatePassword(length: 100).count, 100)
+    }
+}

--- a/passKitTests/Models/PasswordTest.swift
+++ b/passKitTests/Models/PasswordTest.swift
@@ -298,6 +298,29 @@ class PasswordTest: XCTestCase {
         XCTAssertEqual(password.changed, 3)
     }
 
+    func testOtpStringsNoOtpToken() {
+        let password = getPasswordObjectWith(content: "")
+        let otpStrings = password.getOtpStrings()
+
+        XCTAssertNil(otpStrings)
+    }
+
+    func testOtpStringsTotpToken() {
+        let password = getPasswordObjectWith(content: TOTP_URL)
+        let otpStrings = password.getOtpStrings()
+
+        XCTAssertNotNil(otpStrings)
+        XCTAssertTrue(otpStrings!.description.hasPrefix("time-based (expires in"))
+    }
+
+    func testOtpStringsHotpToken() {
+        let password = getPasswordObjectWith(content: HOTP_URL)
+        let otpStrings = password.getOtpStrings()
+
+        XCTAssertNotNil(otpStrings)
+        XCTAssertEqual(otpStrings!.description, "HMAC-based")
+    }
+
     private func getPasswordObjectWith(content: String, url: URL? = nil) -> Password {
         return Password(name: "password", url: url ?? PASSWORD_URL, plainText: content)
     }

--- a/passKitTests/Models/PasswordTest.swift
+++ b/passKitTests/Models/PasswordTest.swift
@@ -167,7 +167,7 @@ class PasswordTest: XCTestCase {
         XCTAssertEqual(password.additionsPlainText, additions)
 
         XCTAssertEqual(password.otpType, OtpType.totp)
-        XCTAssertNotNil(password.getOtp())
+        XCTAssertNotNil(password.currentOtp)
     }
 
     func testFirstLineIsOtpToken() {
@@ -182,7 +182,7 @@ class PasswordTest: XCTestCase {
         XCTAssertNil(password.login)
 
         XCTAssertEqual(password.otpType, OtpType.totp)
-        XCTAssertNotNil(password.getOtp())
+        XCTAssertNotNil(password.currentOtp)
     }
 
     func testWrongOtpToken() {
@@ -194,7 +194,7 @@ class PasswordTest: XCTestCase {
         XCTAssertTrue(password.additionsPlainText.isEmpty)
 
         XCTAssertEqual(password.otpType, OtpType.none)
-        XCTAssertNil(password.getOtp())
+        XCTAssertNil(password.currentOtp)
     }
 
     func testEmptyMultilineValues() {

--- a/passKitTests/Parser/OtpTypeTest.swift
+++ b/passKitTests/Parser/OtpTypeTest.swift
@@ -1,8 +1,8 @@
 //
-//  PasswordHelpersTest.swift
+//  OtpTypeTest.swift
 //  passKitTests
 //
-//  Created by Danny Moesch on 30.09.18.
+//  Created by Danny Moesch on 01.12.18.
 //  Copyright © 2018 Bob Sun. All rights reserved.
 //
 
@@ -11,9 +11,9 @@ import XCTest
 
 @testable import passKit
 
-class PasswordHelpersTest: XCTestCase {
+class OtpTypeTest: XCTestCase {
 
-    func testOtpType() {
+    func testInitFromToken() {
         let secret = "secret".data(using: .utf8)!
 
         let totpGenerator = Generator(factor: .timer(period: 30.0), secret: secret, algorithm: .sha1, digits: 6)!
@@ -25,5 +25,15 @@ class PasswordHelpersTest: XCTestCase {
         XCTAssertEqual(OtpType(token: hotpToken), .hotp)
 
         XCTAssertEqual(OtpType(token: nil), .none)
+    }
+
+    func testInitFromString() {
+        XCTAssertEqual(OtpType(name: "totp"), .totp)
+        XCTAssertEqual(OtpType(name: "tOtP"), .totp)
+        XCTAssertEqual(OtpType(name: "hotp"), .hotp)
+        XCTAssertEqual(OtpType(name: "HoTp"), .hotp)
+        XCTAssertEqual(OtpType(name: nil), .none)
+        XCTAssertEqual(OtpType(name: ""), .none)
+        XCTAssertEqual(OtpType(name: "something"), .none)
     }
 }

--- a/passKitTests/Parser/OtpTypeTest.swift
+++ b/passKitTests/Parser/OtpTypeTest.swift
@@ -36,4 +36,10 @@ class OtpTypeTest: XCTestCase {
         XCTAssertEqual(OtpType(name: ""), .none)
         XCTAssertEqual(OtpType(name: "something"), .none)
     }
+
+    func testDescription() {
+        XCTAssertEqual(OtpType(name: "totp").description, "time-based")
+        XCTAssertEqual(OtpType(name: "hotp").description, "HMAC-based")
+        XCTAssertEqual(OtpType(name: nil).description, "none")
+    }
 }

--- a/passKitTests/Parser/TokenBuilderTest.swift
+++ b/passKitTests/Parser/TokenBuilderTest.swift
@@ -1,0 +1,214 @@
+//
+//  TokenBuilderTest.swift
+//  passKitTests
+//
+//  Created by Danny Moesch on 01.12.18.
+//  Copyright © 2018 Bob Sun. All rights reserved.
+//
+
+import Base32
+import OneTimePassword
+import XCTest
+
+@testable import passKit
+
+class TokenBuilderTest: XCTestCase {
+
+    private let SECRET = "secret"
+    private let DIGITS = Constants.DEFAULT_DIGITS
+    private let TIMER = Generator.Factor.timer(period: Constants.DEFAULT_PERIOD)
+
+    func testNoSecret() {
+        XCTAssertNil(TokenBuilder().build())
+        XCTAssertNil(TokenBuilder().usingSecret(nil).build())
+        XCTAssertNil(TokenBuilder().usingSecret("").build())
+    }
+
+    func testDefault() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .build()
+
+        XCTAssertEqual(token?.generator.secret, MF_Base32Codec.data(fromBase32String: SECRET))
+        XCTAssertEqual(token?.generator.factor, TIMER)
+        XCTAssertEqual(token?.generator.algorithm, .sha1)
+        XCTAssertEqual(token?.generator.digits, DIGITS)
+    }
+
+    func testName() {
+        [
+            "some name",
+            "a",
+            "totp",
+        ].forEach { name in
+            let token = TokenBuilder()
+                .usingName(name)
+                .usingSecret(SECRET)
+                .build()
+
+            XCTAssertEqual(token?.name, name)
+        }
+    }
+
+    func testTypeNone() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingType("something")
+            .build()
+
+        XCTAssertNil(token)
+    }
+
+    func testTypeTotp() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingType("toTp")
+            .build()
+
+        XCTAssertEqual(token?.generator.factor, TIMER)
+    }
+
+    func testTypeHotp() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingType("HotP")
+            .usingCounter("4")
+            .build()
+
+        XCTAssertEqual(token?.generator.factor, Generator.Factor.counter(4))
+    }
+
+    func testAlgorithm() {
+        [
+            ("sha1", .sha1),
+            ("something", .sha1),
+            (nil, .sha1),
+            ("sha256", .sha256),
+            ("Sha256", .sha256),
+            ("sha512", .sha512),
+            ("sHA512", .sha512),
+        ].forEach { (inputAlgorithm: String?, algorithm: Generator.Algorithm) in
+            let token = TokenBuilder()
+                .usingSecret(SECRET)
+                .usingAlgorithm(inputAlgorithm)
+                .build()
+
+            XCTAssertEqual(token?.generator.algorithm, algorithm)
+        }
+    }
+
+    func testDigits() {
+        [
+            (nil, nil),
+            (5, nil),
+            (6, 6),
+            (7, 7),
+            (8, 8),
+            (9, nil),
+        ].forEach { inputDigits, digits in
+            let token = TokenBuilder()
+                .usingSecret(SECRET)
+                .usingDigits(inputDigits == nil ? nil : String(inputDigits!))
+                .build()
+
+            XCTAssertEqual(token?.generator.digits, digits)
+        }
+    }
+
+    func testUnparsableDigits() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingDigits("unparsable digits")
+            .build()
+
+        XCTAssertNil(token)
+    }
+
+    func testPeriod() {
+        [
+            (nil, nil),
+            (1.2, 1.2),
+            (-12.0, nil),
+            (27.5, 27.5),
+            (35.0, 35.0),
+            (120.7, 120.7),
+        ].forEach { inputPeriod, period in
+            let token = TokenBuilder()
+                .usingSecret(SECRET)
+                .usingPeriod(inputPeriod == nil ? nil : String(inputPeriod!))
+                .build()
+            let timer = period == nil ? nil : Generator.Factor.timer(period: period!)
+
+            XCTAssertEqual(token?.generator.factor, timer)
+        }
+    }
+
+    func testUnparsablePeriod() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingPeriod("unparsable period")
+            .build()
+
+        XCTAssertNil(token)
+    }
+
+    func testCounter() {
+        [
+            (nil, nil),
+            (1, 1),
+            (0, 0),
+            (27, 27),
+            (120, 120),
+            (4321, 4321),
+        ].forEach { inputCounter, counter in
+            let token = TokenBuilder()
+                .usingSecret(SECRET)
+                .usingType("hotp")
+                .usingCounter(inputCounter == nil ? nil : String(inputCounter!))
+                .build()
+            let counter = counter == nil ? nil : Generator.Factor.counter(UInt64(counter!))
+
+            XCTAssertEqual(token?.generator.factor, counter)
+        }
+    }
+
+    func testUnparsableCounter() {
+        let token = TokenBuilder()
+            .usingSecret(SECRET)
+            .usingType("hotp")
+            .usingCounter("unparsable counter")
+            .build()
+
+        XCTAssertNil(token)
+    }
+
+    func testAllMixed() {
+        let builder = TokenBuilder()
+            .usingName("name")
+            .usingSecret(SECRET)
+            .usingAlgorithm("sha512")
+            .usingDigits("7")
+            .usingPeriod("42")
+            .usingCounter("12")
+
+        let totpToken = builder.usingType("totp").build()
+
+        XCTAssertNotNil(totpToken)
+        XCTAssertEqual(totpToken?.name, "name")
+        XCTAssertEqual(totpToken?.currentPassword?.count, 7)
+        XCTAssertEqual(totpToken?.generator.algorithm, .sha512)
+        XCTAssertEqual(totpToken?.generator.digits, 7)
+        XCTAssertEqual(totpToken?.generator.factor, .timer(period: 42))
+        XCTAssertEqual(totpToken?.generator.secret, MF_Base32Codec.data(fromBase32String: SECRET))
+
+        let hotpToken = builder.usingType("hotp").build()
+
+        XCTAssertNotNil(hotpToken)
+        XCTAssertEqual(hotpToken?.name, "name")
+        XCTAssertEqual(hotpToken?.currentPassword?.count, 7)
+        XCTAssertEqual(hotpToken?.generator.algorithm, .sha512)
+        XCTAssertEqual(hotpToken?.generator.digits, 7)
+        XCTAssertEqual(hotpToken?.generator.factor, .counter(12))
+        XCTAssertEqual(hotpToken?.generator.secret, MF_Base32Codec.data(fromBase32String: SECRET))
+    }
+}


### PR DESCRIPTION
The main content of this PR is the separation of the OTP token generation from the `Password` class to be able to unit-test it. Therefore, a `TokenBuilder` is introduced.

Furthermore, some smaller changes and fixes have been done:
* Remove YAML errors
* Create constants for commonly used strings
* Separate password creation from `Password`, too
* Ignore case of OTP keywords everywhere
* Add tests for (almost) all the changes 