### PR TITLE
Some code and test improvements

### DIFF
--- a/pass/Controllers/PasswordDetailTableViewController.swift
+++ b/pass/Controllers/PasswordDetailTableViewController.swift
@@ -24,42 +24,18 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
         return uiBarButtonItem
     }()
 
-    private struct TableCell {
-        var title: String
-        var content: String
-        init() {
-            title = ""
-            content = ""
-        }
-
-        init(title: String) {
-            self.title = title
-            self.content = ""
-        }
-
-        init(title: String, content: String) {
-            self.title = title
-            self.content = content
-        }
-    }
-
     private struct TableSection {
         var type: PasswordDetailTableViewControllerSectionType
         var header: String?
-        var item: Array<TableCell>
-        init(type: PasswordDetailTableViewControllerSectionType) {
-            self.type = type
-            header = nil
-            item = [TableCell]()
-        }
+        var item: [AdditionField] = []
 
-        init(type: PasswordDetailTableViewControllerSectionType, header: String) {
-            self.init(type: type)
+        init(type: PasswordDetailTableViewControllerSectionType, header: String? = nil) {
+            self.type = type
             self.header = header
         }
     }
 
-    private var tableData = Array<TableSection>()
+    private var tableData = [TableSection]()
 
     private enum PasswordDetailTableViewControllerSectionType {
         case name, main, addition, misc
@@ -194,8 +170,7 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
             switch otpType {
             case .totp:
                 if let (title, otp) = strongSelf.password?.getOtpStrings() {
-                    strongSelf.tableData[indexPath.section].item[indexPath.row].title = title
-                    strongSelf.tableData[indexPath.section].item[indexPath.row].content = otp
+                    strongSelf.tableData[indexPath.section].item[indexPath.row] = title => otp
                     cell.cellData?.title = title
                     cell.cellData?.content = otp
                 }
@@ -246,19 +221,19 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
 
         // name section
         var section = TableSection(type: .name)
-        section.item.append(TableCell())
+        section.item.append(AdditionField())
         tableData.append(section)
 
         // main section
         section = TableSection(type: .main)
         let password = self.password!
         if let username = password.username {
-            section.item.append(TableCell(title: "username", content: username))
+            section.item.append(Constants.USERNAME_KEYWORD => username)
         }
         if let login = password.login {
-            section.item.append(TableCell(title: "login", content: login))
+            section.item.append(Constants.LOGIN_KEYWORD => login)
         }
-        section.item.append(TableCell(title: "password", content: password.password))
+        section.item.append(Constants.PASSWORD_KEYWORD => password.password)
         tableData.append(section)
 
 
@@ -268,7 +243,7 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
         if password.otpType != .none {
             if let (title, otp) = self.password?.getOtpStrings() {
                 section = TableSection(type: .addition, header: "One Time Password")
-                section.item.append(TableCell(title: title, content: otp))
+                section.item.append(title => otp)
                 tableData.append(section)
                 oneTimePasswordIndexPath = IndexPath(row: 0, section: tableData.count - 1)
             }
@@ -278,15 +253,13 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
         let filteredAdditionKeys = password.getFilteredAdditions()
         if filteredAdditionKeys.count > 0 {
             section = TableSection(type: .addition, header: "additions")
-            filteredAdditionKeys.forEach({ field in
-                section.item.append(TableCell(title: field.title, content: field.content))
-            })
+            section.item.append(contentsOf: filteredAdditionKeys)
             tableData.append(section)
         }
 
         // misc section
         section = TableSection(type: .misc)
-        section.item.append(TableCell(title: "Show Raw"))
+        section.item.append(AdditionField(title: "Show Raw"))
         tableData.append(section)
 
     }

--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -21,6 +21,7 @@ public class Password {
     private var parser = Parser(plainText: "")
     private var additions = [AdditionField]()
     private var firstLineIsOTPField = false
+
     private var otpToken: Token? {
         didSet {
             otpType = OtpType(token: otpToken)
@@ -82,11 +83,11 @@ public class Password {
 
         if self.plainText != plainText {
             self.plainText = plainText
-            changed = changed|PasswordChange.content.rawValue
+            changed |= PasswordChange.content.rawValue
         }
         if self.url != url {
             self.url = url
-            changed = changed|PasswordChange.path.rawValue
+            changed |= PasswordChange.path.rawValue
         }
 
         self.name = name
@@ -171,7 +172,7 @@ public class Password {
             return nil
         }
         var description = otpType.description
-        if case let .timer(period)? = otpToken?.generator.factor {
+        if case let .timer(period) = otpToken!.generator.factor {
             let timeSinceEpoch = Date().timeIntervalSince1970
             let validTime = Int(period - timeSinceEpoch.truncatingRemainder(dividingBy: period))
             description += " (expires in \(validTime)s)"

--- a/passKit/Models/PasswordEntity.swift
+++ b/passKit/Models/PasswordEntity.swift
@@ -12,13 +12,10 @@ import SwiftyUserDefaults
 extension PasswordEntity {
 
     public var nameWithCategory: String {
-        get {
-            if let p = path, p.hasSuffix(".gpg") {
-                return String(p.prefix(upTo: p.index(p.endIndex, offsetBy: -4)))
-            } else {
-                return ""
-            }
+        if let p = path, p.hasSuffix(".gpg") {
+            return String(p.prefix(upTo: p.index(p.endIndex, offsetBy: -4)))
         }
+        return ""
     }
 
     public func getCategoryText() -> String {

--- a/passKit/Parser/AdditionField.swift
+++ b/passKit/Parser/AdditionField.swift
@@ -10,6 +10,11 @@ public struct AdditionField: Hashable {
 
     public let title: String, content: String
 
+    public init(title: String = "", content: String = "") {
+        self.title = title
+        self.content = content
+    }
+
     var asString: String {
         return title.isEmpty ? content : title + ": " + content
     }
@@ -42,6 +47,6 @@ extension AdditionField: Equatable {
 }
 
 infix operator =>: MultiplicationPrecedence
-func => (key: String, value: String) -> AdditionField {
+public func => (key: String, value: String) -> AdditionField {
     return AdditionField(title: key, content: value)
 }

--- a/passKit/Parser/Constants.swift
+++ b/passKit/Parser/Constants.swift
@@ -41,11 +41,12 @@ public struct Constants {
     static let MULTILINE_WITHOUT_LINE_BREAK_SEPARATOR = BLANK
 
     static let OTPAUTH_URL_START = "\(OTPAUTH)://"
-    static let PASSWORD_KEYWORD = "password"
-    static let USERNAME_KEYWORD = "username"
-    static let LOGIN_KEYWORD = "login"
-    static let URL_KEYWORD = "url"
-    static let UNKNOWN = "unknown"
+
+    public static let PASSWORD_KEYWORD = "password"
+    public static let USERNAME_KEYWORD = "username"
+    public static let LOGIN_KEYWORD = "login"
+    public static let URL_KEYWORD = "url"
+    public static let UNKNOWN = "unknown"
 
     public static func isOtpRelated(line: String) -> Bool {
         let (key, _) = Parser.getKeyValuePair(from: line)

--- a/passKitTests/Models/PasswordTest.swift
+++ b/passKitTests/Models/PasswordTest.swift
@@ -35,7 +35,7 @@ class PasswordTest: XCTestCase {
             XCTAssertEqual(password.password, "")
             XCTAssertEqual(password.plainData, fileContent.data(using: .utf8))
             XCTAssertEqual(password.additionsPlainText, "")
-            XCTAssertTrue(password.getFilteredAdditions().isEmpty)
+            XCTAssert(password.getFilteredAdditions().isEmpty)
             XCTAssertEqual(password.numberOfUnknowns, 0)
 
             XCTAssertNil(password.username)
@@ -224,7 +224,7 @@ class PasswordTest: XCTestCase {
 
         XCTAssertEqual(password.password, fileContent)
         XCTAssertEqual(password.plainData, fileContent.data(using: .utf8))
-        XCTAssertTrue(password.additionsPlainText.isEmpty)
+        XCTAssert(password.additionsPlainText.isEmpty)
         XCTAssertEqual(password.numberOfUnknowns, 0)
 
         XCTAssertEqual(password.numberOfOtpRelated, 0)
@@ -306,7 +306,7 @@ class PasswordTest: XCTestCase {
         let otpStrings = password.getOtpStrings()
 
         XCTAssertNotNil(otpStrings)
-        XCTAssertTrue(otpStrings!.description.hasPrefix("time-based (expires in"))
+        XCTAssert(otpStrings!.description.hasPrefix("time-based (expires in"))
     }
 
     func testOtpStringsHotpToken() {

--- a/passKitTests/Models/PasswordTest.swift
+++ b/passKitTests/Models/PasswordTest.swift
@@ -12,6 +12,12 @@ import XCTest
 
 class PasswordTest: XCTestCase {
 
+    override static func setUp() {
+        super.setUp()
+        SharedDefaults[.isHideUnknownOn] = false
+        SharedDefaults[.isHideOTPOn] = false
+    }
+
     func testUrl() {
         let password = getPasswordObjectWith(content: "")
 

--- a/passKitTests/Parser/AdditionFieldTest.swift
+++ b/passKitTests/Parser/AdditionFieldTest.swift
@@ -21,9 +21,9 @@ class AdditionFieldTest: XCTestCase {
         XCTAssertEqual(field2.asString, "no content: ")
         XCTAssertEqual(field3.asString, "no title")
 
-        XCTAssertTrue(field1.asTuple == ("key", "value"))
-        XCTAssertTrue(field2.asTuple == ("no content", ""))
-        XCTAssertTrue(field3.asTuple == ("", "no title"))
+        XCTAssert(field1.asTuple == ("key", "value"))
+        XCTAssert(field2.asTuple == ("no content", ""))
+        XCTAssert(field3.asTuple == ("", "no title"))
     }
 
     func testAdditionFieldEquals() {

--- a/passKitTests/Parser/AdditionFieldTest.swift
+++ b/passKitTests/Parser/AdditionFieldTest.swift
@@ -13,16 +13,16 @@ import XCTest
 class AdditionFieldTest: XCTestCase {
 
     func testAdditionField() {
-        let field1 = "key" => "value"
-        let field2 = "some other key" => "some other value"
-        let field3 = "" => "no title"
+        let field1 = AdditionField(title: "key", content: "value")
+        let field2 = AdditionField(title: "no content")
+        let field3 = AdditionField(content: "no title")
 
         XCTAssertEqual(field1.asString, "key: value")
-        XCTAssertEqual(field2.asString, "some other key: some other value")
+        XCTAssertEqual(field2.asString, "no content: ")
         XCTAssertEqual(field3.asString, "no title")
 
         XCTAssertTrue(field1.asTuple == ("key", "value"))
-        XCTAssertTrue(field2.asTuple == ("some other key", "some other value"))
+        XCTAssertTrue(field2.asTuple == ("no content", ""))
         XCTAssertTrue(field3.asTuple == ("", "no title"))
     }
 

--- a/passKitTests/Parser/ConstantsTest.swift
+++ b/passKitTests/Parser/ConstantsTest.swift
@@ -13,22 +13,22 @@ import XCTest
 class ConstantsTest: XCTestCase {
 
     func testIsOtpRelated() {
-        XCTAssertTrue(Constants.isOtpRelated(line: "otpauth://something"))
-        XCTAssertTrue(Constants.isOtpRelated(line: "otp_algorithm: algorithm"))
+        XCTAssert(Constants.isOtpRelated(line: "otpauth://something"))
+        XCTAssert(Constants.isOtpRelated(line: "otp_algorithm: algorithm"))
         XCTAssertFalse(Constants.isOtpRelated(line: "otp: something"))
         XCTAssertFalse(Constants.isOtpRelated(line: "otp"))
     }
 
     func testIsOtpKeyword() {
-        XCTAssertTrue(Constants.isOtpKeyword("otpauth"))
-        XCTAssertTrue(Constants.isOtpKeyword("oTP_DigITS"))
+        XCTAssert(Constants.isOtpKeyword("otpauth"))
+        XCTAssert(Constants.isOtpKeyword("oTP_DigITS"))
         XCTAssertFalse(Constants.isOtpKeyword("otp"))
         XCTAssertFalse(Constants.isOtpKeyword("no keyword"))
     }
 
     func testIsUnknown() {
-        XCTAssertTrue(Constants.isUnknown("unknown"))
-        XCTAssertTrue(Constants.isUnknown("unknown string"))
+        XCTAssert(Constants.isUnknown("unknown"))
+        XCTAssert(Constants.isUnknown("unknown string"))
         XCTAssertFalse(Constants.isUnknown("otp"))
         XCTAssertFalse(Constants.isUnknown("Unknown"))
     }

--- a/passKitTests/Parser/ParserTest.swift
+++ b/passKitTests/Parser/ParserTest.swift
@@ -28,12 +28,12 @@ class ParserTest: XCTestCase {
     }
 
     func testGetKeyValuePair() {
-        XCTAssertTrue(Parser.getKeyValuePair(from: "key: value") == ("key", "value"))
-        XCTAssertTrue(Parser.getKeyValuePair(from: "a key: a value") == ("a key", "a value"))
-        XCTAssertTrue(Parser.getKeyValuePair(from: "key:value") == (nil, "key:value"))
-        XCTAssertTrue(Parser.getKeyValuePair(from: ": value") == (nil, "value"))
-        XCTAssertTrue(Parser.getKeyValuePair(from: "key: ") == ("key", ""))
-        XCTAssertTrue(Parser.getKeyValuePair(from: "otpauth://value") == ("otpauth", "otpauth://value"))
+        XCTAssert(Parser.getKeyValuePair(from: "key: value") == ("key", "value"))
+        XCTAssert(Parser.getKeyValuePair(from: "a key: a value") == ("a key", "a value"))
+        XCTAssert(Parser.getKeyValuePair(from: "key:value") == (nil, "key:value"))
+        XCTAssert(Parser.getKeyValuePair(from: ": value") == (nil, "value"))
+        XCTAssert(Parser.getKeyValuePair(from: "key: ") == ("key", ""))
+        XCTAssert(Parser.getKeyValuePair(from: "otpauth://value") == ("otpauth", "otpauth://value"))
     }
 
     func testEmptyFiles() {


### PR DESCRIPTION
This PR removes the `TableCell` struct as it is nothing more than the `AdditionField` struct in `passKit`. Additionally, it makes sure that unknown and OTP fields are not hidden before running any test in `PasswordTest`.