### PR TITLE
Correct commit number in "About Repository" view

### DIFF
--- a/pass/Controllers/AboutRepositoryTableViewController.swift
+++ b/pass/Controllers/AboutRepositoryTableViewController.swift
@@ -51,7 +51,7 @@ class AboutRepositoryTableViewController: BasicStaticTableViewController {
             let size = self.sizeOfRepositoryString()
             let localCommits = self.numberOfLocalCommitsString()
             let lastSynced = self.lastSyncedTimeString()
-            let commits = self.numberOfPasswordsString()
+            let commits = self.numberOfCommitsString()
 
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else {
@@ -96,6 +96,10 @@ class AboutRepositoryTableViewController: BasicStaticTableViewController {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+
+    private func numberOfCommitsString() -> String {
+        return String(passwordStore.numberOfCommits)
     }
 
     @objc func setNeedRefresh() {

--- a/pass/Controllers/AboutRepositoryTableViewController.swift
+++ b/pass/Controllers/AboutRepositoryTableViewController.swift
@@ -11,6 +11,8 @@ import passKit
 
 class AboutRepositoryTableViewController: BasicStaticTableViewController {
 
+    private static let VALUE_NOT_AVAILABLE = "Value not available"
+
     private var needRefresh = false
     private var indicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
@@ -85,7 +87,10 @@ class AboutRepositoryTableViewController: BasicStaticTableViewController {
     }
 
     private func numberOfLocalCommitsString() -> String {
-        return String(passwordStore.numberOfLocalCommits)
+        if let numberOfLocalCommits = passwordStore.numberOfLocalCommits {
+            return String(numberOfLocalCommits)
+        }
+        return AboutRepositoryTableViewController.VALUE_NOT_AVAILABLE
     }
 
     private func lastSyncedTimeString() -> String {
@@ -99,7 +104,10 @@ class AboutRepositoryTableViewController: BasicStaticTableViewController {
     }
 
     private func numberOfCommitsString() -> String {
-        return String(passwordStore.numberOfCommits)
+        if let numberOfCommits = passwordStore.numberOfCommits {
+            return String(numberOfCommits)
+        }
+        return AboutRepositoryTableViewController.VALUE_NOT_AVAILABLE
     }
 
     @objc func setNeedRefresh() {

--- a/pass/Controllers/PasswordsViewController.swift
+++ b/pass/Controllers/PasswordsViewController.swift
@@ -138,7 +138,6 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
         SVProgressHUD.setDefaultMaskType(.black)
         SVProgressHUD.setDefaultStyle(.light)
         SVProgressHUD.show(withStatus: "Sync Password Store")
-        let numberOfLocalCommits = self.passwordStore.numberOfLocalCommits
         var gitCredential: GitCredential
         if SharedDefaults[.gitAuthenticationMethod] == "Password" {
             gitCredential = GitCredential(credential: GitCredential.Credential.http(userName: SharedDefaults[.gitUsername]!))
@@ -157,7 +156,7 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
                         SVProgressHUD.showProgress(Float(git_transfer_progress.pointee.received_objects)/Float(git_transfer_progress.pointee.total_objects), status: "Pull Remote Repository")
                     }
                 })
-                if numberOfLocalCommits > 0 {
+                if self.passwordStore.numberOfLocalCommits ?? 0 > 0 {
                     try self.passwordStore.pushRepository(credential: gitCredential, requestGitPassword: self.requestGitPassword(credential:lastPassword:), transferProgressBlock: {(current, total, bytes, stop) in
                         DispatchQueue.main.async {
                             SVProgressHUD.showProgress(Float(current)/Float(total), status: "Push Remote Repository")
@@ -518,11 +517,10 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
 
     private func reloadTableView(data: [PasswordsTableEntry], anim: CAAnimation? = nil) {
         // set navigation item
-        let numberOfLocalCommits = self.passwordStore.numberOfLocalCommits
-        if numberOfLocalCommits == 0 {
-            navigationController?.tabBarItem.badgeValue = nil
-        } else {
+        if let numberOfLocalCommits = passwordStore.numberOfLocalCommits, numberOfLocalCommits != 0 {
             navigationController?.tabBarItem.badgeValue = "\(numberOfLocalCommits)"
+        } else {
+            navigationController?.tabBarItem.badgeValue = nil
         }
         if parentPasswordEntity != nil {
             navigationItem.leftBarButtonItem = backUIBarButtonItem

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -105,16 +105,16 @@ public class PasswordStore {
         return (try? fm.allocatedSizeOfDirectoryAtURL(directoryURL: self.storeURL)) ?? 0
     }
 
-    public var numberOfLocalCommits: Int {
-        return (try? getLocalCommits()?.count ?? 0) ?? 0
+    public var numberOfLocalCommits: Int? {
+        return (try? getLocalCommits())?.flatMap { $0.count }
     }
 
     public var lastSyncedTime: Date? {
         return SharedDefaults[.lastSyncedTime]
     }
 
-    public var numberOfCommits: UInt {
-        return storeRepository?.numberOfCommits(inCurrentBranch: nil) ?? 0
+    public var numberOfCommits: UInt? {
+        return storeRepository?.numberOfCommits(inCurrentBranch: nil)
     }
 
     private init() {

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -113,6 +113,10 @@ public class PasswordStore {
         return SharedDefaults[.lastSyncedTime]
     }
 
+    public var numberOfCommits: UInt {
+        return storeRepository?.numberOfCommits(inCurrentBranch: nil) ?? 0
+    }
+
     private init() {
         // File migration to group
         migrateIfNeeded()


### PR DESCRIPTION
I noticed that the number of (all) commits shown in the "About Repository" view is actually the number of passwords in the repository. With this PR the expected number is displayed. In addition, if an error occurs computing the numbers of commits the view will not show "0" anymore. Instead "Value not available" is displayed.