### PR TITLE
Fix broken search in languages other than English

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		301F6463216162550071A4CE /* AdditionField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6462216162550071A4CE /* AdditionField.swift */; };
 		301F6468216165290071A4CE /* ConstantsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6467216165290071A4CE /* ConstantsTest.swift */; };
 		301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F646C216166AA0071A4CE /* AdditionFieldTest.swift */; };
+		302202EF222F14E400555236 /* SearchBarScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302202EE222F14E400555236 /* SearchBarScope.swift */; };
 		302E85612125ECC70031BA64 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85602125ECC70031BA64 /* Parser.swift */; };
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
 		30697C2A21F63C5A0064FCAC /* NotificationNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30697C2321F63C580064FCAC /* NotificationNames.swift */; };
@@ -202,6 +203,7 @@
 		301F6462216162550071A4CE /* AdditionField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionField.swift; sourceTree = "<group>"; };
 		301F6467216165290071A4CE /* ConstantsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTest.swift; sourceTree = "<group>"; };
 		301F646C216166AA0071A4CE /* AdditionFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionFieldTest.swift; sourceTree = "<group>"; };
+		302202EE222F14E400555236 /* SearchBarScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarScope.swift; sourceTree = "<group>"; };
 		302E85602125ECC70031BA64 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		30697C2321F63C580064FCAC /* NotificationNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationNames.swift; sourceTree = "<group>"; };
@@ -658,8 +660,9 @@
 			isa = PBXGroup;
 			children = (
 				A2BC54C71EEE5669001FAFBD /* Objective-CBridgingHeader.h */,
-				A2A61C1F1EEFABAD00CFE063 /* UtilsExtension.swift */,
+				302202EE222F14E400555236 /* SearchBarScope.swift */,
 				A20691F31F2A3D0E0096483D /* SecurePasteboard.swift */,
+				A2A61C1F1EEFABAD00CFE063 /* UtilsExtension.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1283,6 +1286,7 @@
 				DCFB77AB1E503729008DE471 /* ContentTableViewCell.swift in Sources */,
 				DCA0499C1E3362F400522E8F /* PGPKeySettingTableViewController.swift in Sources */,
 				DC4914961E434301007FF592 /* LabelTableViewCell.swift in Sources */,
+				302202EF222F14E400555236 /* SearchBarScope.swift in Sources */,
 				DC5F385B1E56AADB00C69ACA /* PGPKeyArmorSettingTableViewController.swift in Sources */,
 				DCAAF7451E2FA66800AB94BC /* SettingsTableViewController.swift in Sources */,
 				DCFB77A71E502DF9008DE471 /* EditPasswordTableViewController.swift in Sources */,

--- a/pass/Controllers/PasswordsViewController.swift
+++ b/pass/Controllers/PasswordsViewController.swift
@@ -194,7 +194,7 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
         super.viewDidAppear(animated)
 
         if SharedDefaults[.isShowFolderOn] {
-            searchController.searchBar.scopeButtonTitles = ["Current".localize(), "All".localize()]
+            searchController.searchBar.scopeButtonTitles = SearchBarScope.allCases.map { $0.localizedName }
         } else {
             searchController.searchBar.scopeButtonTitles = nil
         }
@@ -487,9 +487,9 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
         }
     }
 
-    func filterContentForSearchText(searchText: String, scope: String = "All") {
+    func filterContentForSearchText(searchText: String, scope: SearchBarScope = .all) {
         switch scope {
-        case "All":
+        case .all:
             filteredPasswordsTableEntries = passwordsTableAllEntries.filter { entry in
                 let name = entry.passwordEntity?.nameWithCategory ?? entry.title
                 return name.localizedCaseInsensitiveContains(searchText)
@@ -499,7 +499,7 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
             } else {
                 reloadTableView(data: passwordsTableAllEntries)
             }
-        case "Current":
+        case .current:
             filteredPasswordsTableEntries = passwordsTableEntries.filter { entry in
                 return entry.title.lowercased().contains(searchText.lowercased())
             }
@@ -508,8 +508,6 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
             } else {
                 reloadTableView(data: passwordsTableEntries)
             }
-        default:
-            break
         }
 
 
@@ -587,7 +585,7 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
 
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {
         // update the default search scope
-        SharedDefaults[.isSearchDefaultAll] = searchController.searchBar.scopeButtonTitles![selectedScope] == "All"
+        SharedDefaults[.isSearchDefaultAll] = SearchBarScope(rawValue: selectedScope) == .all
         updateSearchResults(for: searchController)
     }
 
@@ -595,16 +593,16 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         // set the default search scope to "all"
         if SharedDefaults[.isShowFolderOn] && SharedDefaults[.isSearchDefaultAll] {
-            searchController.searchBar.selectedScopeButtonIndex = searchController.searchBar.scopeButtonTitles?.index(of: "All") ?? 0
+            searchController.searchBar.selectedScopeButtonIndex = SearchBarScope.all.rawValue
         } else {
-            searchController.searchBar.selectedScopeButtonIndex = 0
+            searchController.searchBar.selectedScopeButtonIndex = SearchBarScope.current.rawValue
         }
         return true
     }
 
     func searchBarShouldEndEditing(_ searchBar: UISearchBar) -> Bool {
         // set the default search scope to "current"
-        searchController.searchBar.selectedScopeButtonIndex = 0
+        searchController.searchBar.selectedScopeButtonIndex = SearchBarScope.current.rawValue
         updateSearchResults(for: searchController)
         return true
     }
@@ -646,10 +644,7 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
 
 extension PasswordsViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        var scope = "All"
-        if let scopeButtonTitles = searchController.searchBar.scopeButtonTitles {
-            scope = scopeButtonTitles[searchController.searchBar.selectedScopeButtonIndex]
-        }
+        let scope = SearchBarScope(rawValue: searchController.searchBar.selectedScopeButtonIndex) ?? .all
         filterContentForSearchText(searchText: searchController.searchBar.text!, scope: scope)
     }
 }

--- a/pass/Helpers/SearchBarScope.swift
+++ b/pass/Helpers/SearchBarScope.swift
@@ -1,0 +1,21 @@
+//
+//  SearchBarScope.swift
+//  pass
+//
+//  Created by Danny Moesch on 05.03.19.
+//  Copyright © 2019 Bob Sun. All rights reserved.
+//
+
+enum SearchBarScope: Int, CaseIterable {
+    case current
+    case all
+
+    var localizedName: String {
+        switch self {
+        case .current:
+            return "Current".localize()
+        case .all:
+            return "All".localize()
+        }
+    }
+}


### PR DESCRIPTION
Currently, the search bar is not working with languages other than English because of strings being used as keys. Together with the localization of these strings the logic breaks and causes the search functionality to do nothing. This PR replaces the strings with enum cases representing both states of the search scope. In addition, this allows for some nice code simplifications. 😊 