### PR TITLE
Hide placeholder image when Hide Password Images is on

### DIFF
--- a/pass/Controllers/PasswordDetailTableViewController.swift
+++ b/pass/Controllers/PasswordDetailTableViewController.swift
@@ -398,9 +398,15 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
         case .name:
             let cell = tableView.dequeueReusableCell(withIdentifier: "passwordDetailTitleTableViewCell", for: indexPath) as! PasswordDetailTitleTableViewCell
             if !SharedDefaults[.isHidePasswordImagesOn] {
-              cell.passwordImageImageView.image = passwordImage ?? #imageLiteral(resourceName: "PasswordImagePlaceHolder")
+                cell.labelCellConstraint.isActive = false
+                cell.labelImageConstraint.isActive = true
+                cell.passwordImageImageView.image = passwordImage ?? #imageLiteral(resourceName: "PasswordImagePlaceHolder")
+                cell.passwordImageImageView.isHidden = false
             } else {
-              cell.passwordImageImageView.image = #imageLiteral(resourceName: "PasswordImagePlaceHolder")
+                cell.passwordImageImageView.image = nil
+                cell.passwordImageImageView.isHidden = true
+                cell.labelImageConstraint.isActive = false
+                cell.labelCellConstraint.isActive = true
             }
             let passwordName = passwordEntity!.getName()
             if passwordEntity!.synced == false {

--- a/pass/Views/PasswordDetailTitleTableViewCell.swift
+++ b/pass/Views/PasswordDetailTitleTableViewCell.swift
@@ -12,6 +12,9 @@ class PasswordDetailTitleTableViewCell: UITableViewCell {
     @IBOutlet weak var categoryLabel: UILabel!
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var passwordImageImageView: UIImageView!
+    @IBOutlet var labelImageConstraint: NSLayoutConstraint!
+    @IBOutlet var labelCellConstraint: NSLayoutConstraint!
+
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/pass/Views/PasswordDetailTitleTableViewCell.xib
+++ b/pass/Views/PasswordDetailTitleTableViewCell.xib
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16F43c" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,21 +18,21 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="83.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" placeholderIntrinsicWidth="52" placeholderIntrinsicHeight="52" translatesAutoresizingMaskIntoConstraints="NO" id="gKV-Cd-wIk">
-                        <rect key="frame" x="15" y="15" width="54" height="54"/>
+                    <imageView opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" placeholderIntrinsicWidth="52" placeholderIntrinsicHeight="52" translatesAutoresizingMaskIntoConstraints="NO" id="gKV-Cd-wIk">
+                        <rect key="frame" x="16" y="15" width="54" height="54"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="999" constant="52" id="Liw-y2-PDc"/>
                             <constraint firstAttribute="width" secondItem="gKV-Cd-wIk" secondAttribute="height" multiplier="1:1" id="rsw-IM-Eh1"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KvF-3d-EbG">
-                        <rect key="frame" x="85" y="21" width="220" height="21"/>
+                        <rect key="frame" x="86" y="21" width="218" height="21"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="category1 &gt; category2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ctk-b6-pjw">
-                        <rect key="frame" x="85" y="48" width="220" height="16"/>
+                        <rect key="frame" x="86" y="48" width="218" height="16"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <nil key="highlightedColor"/>
@@ -45,6 +43,7 @@
                     <constraint firstItem="Ctk-b6-pjw" firstAttribute="leading" secondItem="KvF-3d-EbG" secondAttribute="leading" id="CfQ-pR-HTm"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Ctk-b6-pjw" secondAttribute="trailing" id="GbW-iJ-02i"/>
                     <constraint firstItem="gKV-Cd-wIk" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="4" id="JX5-qI-8f8"/>
+                    <constraint firstItem="KvF-3d-EbG" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" priority="750" id="MN3-Iy-OA1"/>
                     <constraint firstItem="KvF-3d-EbG" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="10" id="OFd-QE-rRm"/>
                     <constraint firstAttribute="bottomMargin" secondItem="gKV-Cd-wIk" secondAttribute="bottom" constant="4" id="fyJ-BI-Jls"/>
                     <constraint firstAttribute="trailingMargin" secondItem="KvF-3d-EbG" secondAttribute="trailing" id="jPo-Fz-5h5"/>
@@ -54,6 +53,8 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="categoryLabel" destination="Ctk-b6-pjw" id="dtM-9v-xH2"/>
+                <outlet property="labelCellConstraint" destination="MN3-Iy-OA1" id="hp8-30-9TO"/>
+                <outlet property="labelImageConstraint" destination="B4p-uV-LTm" id="KcL-U7-vxW"/>
                 <outlet property="nameLabel" destination="KvF-3d-EbG" id="JBt-bD-efA"/>
                 <outlet property="passwordImageImageView" destination="gKV-Cd-wIk" id="Vmf-b7-Zcv"/>
             </connections>


### PR DESCRIPTION
This hides the password image placeholder when `Hide Password Images` is enabled. Auto-layout constraints are toggled on and off depending on the setting's value to ensure correct alignment and matching alignment in the table cells below.

Extends #248