### PR TITLE
Fix #258: Remove keys before moving new ones

### DIFF
--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -838,10 +838,17 @@ public class PasswordStore {
     }
 
     public func gitSSHKeyImportFromFileSharing() throws {
+        if gitSSHKeyExists() {
+            try fm.removeItem(atPath: Globals.gitSSHPrivateKeyPath)
+        }
         try fm.moveItem(atPath: Globals.iTunesFileSharingSSHPrivate, toPath: Globals.gitSSHPrivateKeyPath)
     }
 
     public func pgpKeyImportFromFileSharing() throws {
+        if pgpKeyExists() {
+            try fm.removeItem(atPath: Globals.pgpPublicKeyPath)
+            try fm.removeItem(atPath: Globals.pgpPrivateKeyPath)
+        }
         try fm.moveItem(atPath: Globals.iTunesFileSharingPGPPublic, toPath: Globals.pgpPublicKeyPath)
         try fm.moveItem(atPath: Globals.iTunesFileSharingPGPPrivate, toPath: Globals.pgpPrivateKeyPath)
     }


### PR DESCRIPTION
This may fix the issue in #258 which prevents new key files from being moved into the app in case files with the same name already/still exist.