### PR TITLE
Store PGP keys in Keychain

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		302B2C9822C2BDE700D831EE /* AppKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302B2C9722C2BDE700D831EE /* AppKeychain.swift */; };
 		302E85612125ECC70031BA64 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85602125ECC70031BA64 /* Parser.swift */; };
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
+		3032327422C7F710009EBD9C /* KeyFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3032327322C7F710009EBD9C /* KeyFileManager.swift */; };
+		3032327622C7F7B9009EBD9C /* PgpKeyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3032327522C7F7B9009EBD9C /* PgpKeyType.swift */; };
+		3032328A22C9FBA2009EBD9C /* KeyFileManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3032328922C9FBA2009EBD9C /* KeyFileManagerTest.swift */; };
 		30697C2A21F63C5A0064FCAC /* NotificationNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30697C2321F63C580064FCAC /* NotificationNames.swift */; };
 		30697C2B21F63C5A0064FCAC /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30697C2421F63C590064FCAC /* Globals.swift */; };
 		30697C2C21F63C5A0064FCAC /* FileManagerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30697C2521F63C590064FCAC /* FileManagerExtension.swift */; };
@@ -212,6 +215,9 @@
 		302B2C9722C2BDE700D831EE /* AppKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeychain.swift; sourceTree = "<group>"; };
 		302E85602125ECC70031BA64 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		3032327322C7F710009EBD9C /* KeyFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyFileManager.swift; sourceTree = "<group>"; };
+		3032327522C7F7B9009EBD9C /* PgpKeyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PgpKeyType.swift; sourceTree = "<group>"; };
+		3032328922C9FBA2009EBD9C /* KeyFileManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyFileManagerTest.swift; sourceTree = "<group>"; };
 		30697C2321F63C580064FCAC /* NotificationNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationNames.swift; sourceTree = "<group>"; };
 		30697C2421F63C590064FCAC /* Globals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
 		30697C2521F63C590064FCAC /* FileManagerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileManagerExtension.swift; sourceTree = "<group>"; };
@@ -395,6 +401,7 @@
 			isa = PBXGroup;
 			children = (
 				30A1D29B21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift */,
+				3032328922C9FBA2009EBD9C /* KeyFileManagerTest.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -571,8 +578,10 @@
 				30697C2821F63C590064FCAC /* DefaultsKeys.swift */,
 				30697C2521F63C590064FCAC /* FileManagerExtension.swift */,
 				30697C2421F63C590064FCAC /* Globals.swift */,
+				3032327322C7F710009EBD9C /* KeyFileManager.swift */,
 				30697C2321F63C580064FCAC /* NotificationNames.swift */,
 				30697C2621F63C590064FCAC /* PasswordGeneratorFlavour.swift */,
+				3032327522C7F7B9009EBD9C /* PgpKeyType.swift */,
 				302202EE222F14E400555236 /* SearchBarScope.swift */,
 				30697C2721F63C590064FCAC /* Utils.swift */,
 			);
@@ -1058,6 +1067,7 @@
 				30A1D2A821B2D53200E2D1F7 /* PasswordChange.swift in Sources */,
 				30697C3E21F63C990064FCAC /* String+Utilities.swift in Sources */,
 				302B2C9822C2BDE700D831EE /* AppKeychain.swift in Sources */,
+				3032327422C7F710009EBD9C /* KeyFileManager.swift in Sources */,
 				30697C3B21F63C990064FCAC /* String+Localization.swift in Sources */,
 				302E85612125ECC70031BA64 /* Parser.swift in Sources */,
 				30697C4621F63CAB0064FCAC /* GitCredential.swift in Sources */,
@@ -1068,6 +1078,7 @@
 				30697C2C21F63C5A0064FCAC /* FileManagerExtension.swift in Sources */,
 				30697C3321F63C8B0064FCAC /* PasscodeLockPresenter.swift in Sources */,
 				30697C3D21F63C990064FCAC /* UIViewExtension.swift in Sources */,
+				3032327622C7F7B9009EBD9C /* PgpKeyType.swift in Sources */,
 				30697C3A21F63C990064FCAC /* UIViewControllerExtension.swift in Sources */,
 				30697C2E21F63C5A0064FCAC /* Utils.swift in Sources */,
 				30697C4521F63CAB0064FCAC /* Password.swift in Sources */,
@@ -1085,6 +1096,7 @@
 				30B04860209A5141001013CA /* PasswordTest.swift in Sources */,
 				307BF39921BC2298003A082D /* TestBase.swift in Sources */,
 				30697C5F21F674800064FCAC /* String+UtilitiesTest.swift in Sources */,
+				3032328A22C9FBA2009EBD9C /* KeyFileManagerTest.swift in Sources */,
 				30A1D2AA21B32A0100E2D1F7 /* OtpTypeTest.swift in Sources */,
 				301F6468216165290071A4CE /* ConstantsTest.swift in Sources */,
 				30A1D29C21AF451E00E2D1F7 /* PasswordGeneratorFlavourTest.swift in Sources */,

--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		301F6463216162550071A4CE /* AdditionField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6462216162550071A4CE /* AdditionField.swift */; };
 		301F6468216165290071A4CE /* ConstantsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F6467216165290071A4CE /* ConstantsTest.swift */; };
 		301F646D216166AA0071A4CE /* AdditionFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301F646C216166AA0071A4CE /* AdditionFieldTest.swift */; };
+		302B2C9822C2BDE700D831EE /* AppKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302B2C9722C2BDE700D831EE /* AppKeychain.swift */; };
 		302E85612125ECC70031BA64 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85602125ECC70031BA64 /* Parser.swift */; };
 		302E85632125EE550031BA64 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E85622125EE550031BA64 /* Constants.swift */; };
 		30697C2A21F63C5A0064FCAC /* NotificationNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30697C2321F63C580064FCAC /* NotificationNames.swift */; };
@@ -208,6 +209,7 @@
 		301F6467216165290071A4CE /* ConstantsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTest.swift; sourceTree = "<group>"; };
 		301F646C216166AA0071A4CE /* AdditionFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionFieldTest.swift; sourceTree = "<group>"; };
 		302202EE222F14E400555236 /* SearchBarScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarScope.swift; sourceTree = "<group>"; };
+		302B2C9722C2BDE700D831EE /* AppKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeychain.swift; sourceTree = "<group>"; };
 		302E85602125ECC70031BA64 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		302E85622125EE550031BA64 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		30697C2321F63C580064FCAC /* NotificationNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationNames.swift; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 			isa = PBXGroup;
 			children = (
 				30697C2921F63C590064FCAC /* AppError.swift */,
+				302B2C9722C2BDE700D831EE /* AppKeychain.swift */,
 				30697C2821F63C590064FCAC /* DefaultsKeys.swift */,
 				30697C2521F63C590064FCAC /* FileManagerExtension.swift */,
 				30697C2421F63C590064FCAC /* Globals.swift */,
@@ -1054,6 +1057,7 @@
 				30697C2F21F63C5A0064FCAC /* DefaultsKeys.swift in Sources */,
 				30A1D2A821B2D53200E2D1F7 /* PasswordChange.swift in Sources */,
 				30697C3E21F63C990064FCAC /* String+Utilities.swift in Sources */,
+				302B2C9822C2BDE700D831EE /* AppKeychain.swift in Sources */,
 				30697C3B21F63C990064FCAC /* String+Localization.swift in Sources */,
 				302E85612125ECC70031BA64 /* Parser.swift in Sources */,
 				30697C4621F63CAB0064FCAC /* GitCredential.swift in Sources */,

--- a/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
+++ b/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
@@ -90,8 +90,14 @@ class PGPKeyArmorSettingTableViewController: AutoCellHeightUITableViewController
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        armorPublicKeyTextView.text = String(data: Utils.getDataFromKeychain(for: PasswordStore.PGPKeyType.PUBLIC.rawValue)!, encoding: .ascii)
-        armorPrivateKeyTextView.text = String(data: Utils.getDataFromKeychain(for: PasswordStore.PGPKeyType.PRIVATE.rawValue)!, encoding: .ascii)
+        
+        if let publicKey: Data = AppKeychain.get(for: PasswordStore.PGPKeyType.PUBLIC.rawValue) {
+            armorPublicKeyTextView.text = String(data: publicKey, encoding: .ascii)
+        }
+        if let privateKey: Data = AppKeychain.get(for: PasswordStore.PGPKeyType.PRIVATE.rawValue) {
+            armorPrivateKeyTextView.text = String(data: privateKey, encoding: .ascii)
+        }
+
         pgpPassphrase = passwordStore.pgpKeyPassphrase
 
         scanPublicKeyCell?.textLabel?.text = "ScanPublicKeyQrCodes".localize()

--- a/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
+++ b/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
@@ -90,8 +90,8 @@ class PGPKeyArmorSettingTableViewController: AutoCellHeightUITableViewController
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        armorPublicKeyTextView.text = SharedDefaults[.pgpPublicKeyArmor]
-        armorPrivateKeyTextView.text = SharedDefaults[.pgpPrivateKeyArmor]
+        armorPublicKeyTextView.text = String(data: Utils.getDataFromKeychain(for: PasswordStore.PGPKeyType.PUBLIC.rawValue)!, encoding: .ascii)
+        armorPrivateKeyTextView.text = String(data: Utils.getDataFromKeychain(for: PasswordStore.PGPKeyType.PRIVATE.rawValue)!, encoding: .ascii)
         pgpPassphrase = passwordStore.pgpKeyPassphrase
 
         scanPublicKeyCell?.textLabel?.text = "ScanPublicKeyQrCodes".localize()

--- a/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
+++ b/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
@@ -91,10 +91,10 @@ class PGPKeyArmorSettingTableViewController: AutoCellHeightUITableViewController
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        if let publicKey: Data = AppKeychain.get(for: PasswordStore.PGPKeyType.PUBLIC.rawValue) {
+        if let publicKey: Data = AppKeychain.get(for: PgpKeyType.PUBLIC.getKeychainKey()) {
             armorPublicKeyTextView.text = String(data: publicKey, encoding: .ascii)
         }
-        if let privateKey: Data = AppKeychain.get(for: PasswordStore.PGPKeyType.PRIVATE.rawValue) {
+        if let privateKey: Data = AppKeychain.get(for: PgpKeyType.PRIVATE.getKeychainKey()) {
             armorPrivateKeyTextView.text = String(data: privateKey, encoding: .ascii)
         }
 

--- a/pass/Controllers/SettingsTableViewController.swift
+++ b/pass/Controllers/SettingsTableViewController.swift
@@ -59,17 +59,13 @@ class SettingsTableViewController: UITableViewController, UITabBarControllerDele
             if SharedDefaults[.isRememberPGPPassphraseOn] {
                 self.passwordStore.pgpKeyPassphrase = controller.pgpPassphrase
             }
-
-            SharedDefaults[.pgpPublicKeyArmor] = controller.armorPublicKeyTextView.text!
-            SharedDefaults[.pgpPrivateKeyArmor] = controller.armorPrivateKeyTextView.text!
-
             SVProgressHUD.setDefaultMaskType(.black)
             SVProgressHUD.setDefaultStyle(.light)
             SVProgressHUD.show(withStatus: "FetchingPgpKey".localize())
             DispatchQueue.global(qos: .userInitiated).async { [unowned self] in
                 do {
-                    try self.passwordStore.initPGPKey(with: SharedDefaults[.pgpPublicKeyArmor] ?? "", keyType: .PUBLIC)
-                    try self.passwordStore.initPGPKey(with: SharedDefaults[.pgpPrivateKeyArmor] ?? "", keyType: .PRIVATE)
+                    try self.passwordStore.initPGPKey(with: controller.armorPublicKeyTextView.text ?? "", keyType: .PUBLIC)
+                    try self.passwordStore.initPGPKey(with: controller.armorPrivateKeyTextView.text ?? "", keyType: .PRIVATE)
                     DispatchQueue.main.async {
                         self.pgpKeyTableViewCell.detailTextLabel?.text = self.passwordStore.pgpKeyID
                         SVProgressHUD.showSuccess(withStatus: "Success".localize())

--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "FailureToSaveContext"                  = "Fehler beim Speichern des Kontexts: %@";
 "RepositoryRemoteMasterNotFoundError."  = "Remote-Branch origin/master wurde nicht gefunden.";
 "KeyImportError."                       = "Schlüssel kann nicht importiert werden.";
+"FileNotFoundError."                    = "Die Datei '%@' kann nicht gelesen werden.";
 "PasswordDuplicatedError."              = "Passwort kann nicht hinzugefügt werden; es existiert bereits.";
 "GitResetError."                        = "Der zuletzt synchronisierte Commit kann nicht identifiziert werden.";
 "PGPPublicKeyNotExistError."            = "Der öffentliche PGP-Schlüssen existiert nicht";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "RepositoryRemoteBranchNotFoundError."  = "Cannot find remote branch %@.";
 "RepositoryBranchNotFoundError."        = "Branch %@ not found in repository.";
 "KeyImportError."                       = "Cannot import the key.";
+"FileNotFoundError."                    = "File '%@' cannot be read.";
 "PasswordDuplicatedError."              = "Cannot add the password; password is duplicated.";
 "GitResetError."                        = "Cannot identify the latest synced commit.";
 "PgpPublicKeyNotExistError."            = "PGP public key doesn't exist.";

--- a/passKit/Helpers/AppError.swift
+++ b/passKit/Helpers/AppError.swift
@@ -11,6 +11,7 @@ public enum AppError: Error {
     case RepositoryRemoteBranchNotFound(_: String)
     case RepositoryBranchNotFound(_: String)
     case KeyImport
+    case ReadingFile(_: String)
     case PasswordDuplicated
     case GitReset
     case GitCommit
@@ -26,7 +27,7 @@ extension AppError: LocalizedError {
     public var errorDescription: String? {
         let localizationKey = "\(String(describing: self).prefix(while: { $0 != "(" }))Error."
         switch self {
-        case let .RepositoryRemoteBranchNotFound(name), let .RepositoryBranchNotFound(name):
+        case let .RepositoryRemoteBranchNotFound(name), let .RepositoryBranchNotFound(name), let .ReadingFile(name):
             return localizationKey.localize(name)
         default:
             return localizationKey.localize()

--- a/passKit/Helpers/AppError.swift
+++ b/passKit/Helpers/AppError.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Bob Sun. All rights reserved.
 //
 
-public enum AppError: Error {
+public enum AppError: Error, Equatable {
     case RepositoryNotSet
     case RepositoryRemoteBranchNotFound(_: String)
     case RepositoryBranchNotFound(_: String)

--- a/passKit/Helpers/AppKeychain.swift
+++ b/passKit/Helpers/AppKeychain.swift
@@ -1,0 +1,40 @@
+//
+//  AppKeychain.swift
+//  passKit
+//
+//  Created by Danny Moesch on 25.06.19.
+//  Copyright © 2019 Bob Sun. All rights reserved.
+//
+
+import KeychainAccess
+
+public class AppKeychain {
+    
+    private static let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
+        .accessibility(.whenUnlockedThisDeviceOnly)
+        .synchronizable(false)
+
+    public static func add(data: Data, for key: String) {
+        keychain[data: key] = data
+    }
+
+    public static func add(string: String, for key: String) {
+        keychain[key] = string
+    }
+
+    public static func get(for key: String) -> Data? {
+        return try? keychain.getData(key)
+    }
+
+    public static func get(for key: String) -> String? {
+        return try? keychain.getString(key)
+    }
+
+    public static func removeContent(for key: String) {
+        try? keychain.remove(key)
+    }
+
+    public static func removeAllContent() {
+        try? keychain.removeAll()
+    }
+}

--- a/passKit/Helpers/DefaultsKeys.swift
+++ b/passKit/Helpers/DefaultsKeys.swift
@@ -16,6 +16,10 @@ public extension DefaultsKeys {
     static let pgpPublicKeyURL = DefaultsKey<URL?>("pgpPublicKeyURL")
     static let pgpPrivateKeyURL = DefaultsKey<URL?>("pgpPrivateKeyURL")
 
+    // Keep them for legacy reasons.
+    static let pgpPublicKeyArmor = DefaultsKey<String?>("pgpPublicKeyArmor")
+    static let pgpPrivateKeyArmor = DefaultsKey<String?>("pgpPrivateKeyArmor")
+
     static let gitURL = DefaultsKey<URL?>("gitURL")
     static let gitAuthenticationMethod = DefaultsKey<String?>("gitAuthenticationMethod")
     static let gitUsername = DefaultsKey<String?>("gitUsername")

--- a/passKit/Helpers/DefaultsKeys.swift
+++ b/passKit/Helpers/DefaultsKeys.swift
@@ -16,9 +16,6 @@ public extension DefaultsKeys {
     static let pgpPublicKeyURL = DefaultsKey<URL?>("pgpPublicKeyURL")
     static let pgpPrivateKeyURL = DefaultsKey<URL?>("pgpPrivateKeyURL")
 
-    static let pgpPublicKeyArmor = DefaultsKey<String?>("pgpPublicKeyArmor")
-    static let pgpPrivateKeyArmor = DefaultsKey<String?>("pgpPrivateKeyArmor")
-
     static let gitURL = DefaultsKey<URL?>("gitURL")
     static let gitAuthenticationMethod = DefaultsKey<String?>("gitAuthenticationMethod")
     static let gitUsername = DefaultsKey<String?>("gitUsername")

--- a/passKit/Helpers/KeyFileManager.swift
+++ b/passKit/Helpers/KeyFileManager.swift
@@ -1,0 +1,40 @@
+//
+//  KeyFileManager.swift
+//  passKit
+//
+//  Created by Danny Moesch on 29.06.19.
+//  Copyright © 2019 Bob Sun. All rights reserved.
+//
+
+public class KeyFileManager {
+    public typealias KeyHandler = (Data, String) -> ()
+
+    public static let PublicPgp = KeyFileManager(keyType: PgpKeyType.PUBLIC)
+    public static let PrivatePgp = KeyFileManager(keyType: PgpKeyType.PRIVATE)
+
+    private let keyType: PgpKeyType
+    private let keyPath: String
+    private let keyHandler: KeyHandler
+
+    private convenience init(keyType: PgpKeyType) {
+        self.init(keyType: keyType, keyPath: keyType.getFileSharingPath())
+    }
+
+    public init(keyType: PgpKeyType, keyPath: String, keyHandler: @escaping KeyHandler = AppKeychain.add) {
+        self.keyType = keyType
+        self.keyPath = keyPath
+        self.keyHandler = keyHandler
+    }
+
+    public func importKeyAndDeleteFile() throws {
+        guard let keyFileContent = FileManager.default.contents(atPath: keyPath) else {
+            throw AppError.ReadingFile(URL(fileURLWithPath: keyPath).lastPathComponent)
+        }
+        keyHandler(keyFileContent, keyType.getKeychainKey())
+        try FileManager.default.removeItem(atPath: keyPath)
+    }
+    
+    public func doesKeyFileExist() -> Bool {
+        return FileManager.default.fileExists(atPath: keyPath)
+    }
+}

--- a/passKit/Helpers/PgpKeyType.swift
+++ b/passKit/Helpers/PgpKeyType.swift
@@ -1,0 +1,30 @@
+//
+//  PgpKeyType.swift
+//  passKit
+//
+//  Created by Danny Moesch on 29.06.19.
+//  Copyright © 2019 Bob Sun. All rights reserved.
+//
+
+public enum PgpKeyType {
+    case PUBLIC
+    case PRIVATE
+
+    public func getKeychainKey() -> String {
+        switch self {
+        case .PUBLIC:
+            return "pgpPublicKey"
+        case .PRIVATE:
+            return "pgpPrivateKey"
+        }
+    }
+
+    func getFileSharingPath() -> String {
+        switch self {
+        case .PUBLIC:
+            return Globals.iTunesFileSharingPGPPublic
+        case .PRIVATE:
+            return Globals.iTunesFileSharingPGPPrivate
+        }
+    }
+}

--- a/passKit/Helpers/Utils.swift
+++ b/passKit/Helpers/Utils.swift
@@ -13,6 +13,8 @@ import KeychainAccess
 public class Utils {
 
     private static let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
+        .accessibility(.whenUnlockedThisDeviceOnly)
+        .synchronizable(false)
 
     public static func getPasswordFromKeychain(name: String) -> String? {
         return try? keychain.getString(name)

--- a/passKit/Helpers/Utils.swift
+++ b/passKit/Helpers/Utils.swift
@@ -6,39 +6,7 @@
 //  Copyright © 2017 Bob Sun. All rights reserved.
 //
 
-import Foundation
-import SwiftyUserDefaults
-import KeychainAccess
-
 public class Utils {
-
-    private static let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
-        .accessibility(.whenUnlockedThisDeviceOnly)
-        .synchronizable(false)
-
-    public static func getPasswordFromKeychain(name: String) -> String? {
-        return try? keychain.getString(name)
-    }
-
-    public static func addPasswordToKeychain(name: String, password: String?) {
-        keychain[name] = password
-    }
-
-    public static func removeKeychain(name: String) {
-        try? keychain.remove(name)
-    }
-
-    public static func removeAllKeychain() {
-        try? keychain.removeAll()
-    }
-
-    public static func addDataToKeychain(key: String, data: Data) {
-        keychain[data: key] = data
-    }
-
-    public static func getDataFromKeychain(for key: String) -> Data? {
-        return try? keychain.getData(key)
-    }
 
     public static func copyToPasteboard(textToCopy: String?) {
         guard textToCopy != nil else {

--- a/passKit/Helpers/Utils.swift
+++ b/passKit/Helpers/Utils.swift
@@ -11,31 +11,32 @@ import SwiftyUserDefaults
 import KeychainAccess
 
 public class Utils {
+
+    private static let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
+
     public static func getPasswordFromKeychain(name: String) -> String? {
-        let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
         return try? keychain.getString(name)
     }
 
     public static func addPasswordToKeychain(name: String, password: String?) {
-        let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
         keychain[name] = password
     }
 
     public static func removeKeychain(name: String) {
-        let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
         try? keychain.remove(name)
     }
 
     public static func removeAllKeychain() {
-        let keychain = Keychain(service: Globals.bundleIdentifier, accessGroup: Globals.groupIdentifier)
         try? keychain.removeAll()
     }
+
     public static func copyToPasteboard(textToCopy: String?) {
         guard textToCopy != nil else {
             return
         }
         UIPasteboard.general.string = textToCopy
     }
+
     public static func attributedPassword(plainPassword: String) -> NSAttributedString{
         let attributedPassword = NSMutableAttributedString.init(string: plainPassword)
         // draw all digits in the password into red

--- a/passKit/Helpers/Utils.swift
+++ b/passKit/Helpers/Utils.swift
@@ -32,6 +32,14 @@ public class Utils {
         try? keychain.removeAll()
     }
 
+    public static func addDataToKeychain(key: String, data: Data) {
+        keychain[data: key] = data
+    }
+
+    public static func getDataFromKeychain(for key: String) -> Data? {
+        return try? keychain.getData(key)
+    }
+
     public static func copyToPasteboard(textToCopy: String?) {
         guard textToCopy != nil else {
             return

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -191,11 +191,18 @@ public class PasswordStore {
     }
 
     private func importExistingKeysIntoKeychain() {
-        if let publicKey = fm.contents(atPath: Globals.pgpPublicKeyPath) {
-            AppKeychain.add(data: publicKey, for: PGPKeyType.PUBLIC.rawValue)
-        }
-        if let privateKey = fm.contents(atPath: Globals.pgpPrivateKeyPath) {
-            AppKeychain.add(data: privateKey, for: PGPKeyType.PRIVATE.rawValue)
+        do {
+            if let publicKey = fm.contents(atPath: Globals.pgpPublicKeyPath) {
+                AppKeychain.add(data: publicKey, for: PGPKeyType.PUBLIC.rawValue)
+                try fm.removeItem(atPath: Globals.pgpPublicKeyPath)
+            }
+            if let privateKey = fm.contents(atPath: Globals.pgpPrivateKeyPath) {
+                AppKeychain.add(data: privateKey, for: PGPKeyType.PRIVATE.rawValue)
+                try fm.removeItem(atPath: Globals.pgpPrivateKeyPath)
+            }
+            SharedDefaults[.pgpKeySource] = "file"
+        } catch {
+            print("MigrationError".localize(error))
         }
     }
     

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -126,6 +126,7 @@ public class PasswordStore {
         // File migration to group
         migrateIfNeeded()
         backwardCompatibility()
+        importExistingKeysIntoKeychain()
         
         do {
             if fm.fileExists(atPath: storeURL.path) {
@@ -180,6 +181,15 @@ public class PasswordStore {
         // For the renamed isRememberPGPPassphraseOn (20171008)
         if self.pgpKeyPassphrase != nil && SharedDefaults[.isRememberPGPPassphraseOn] == false {
             SharedDefaults[.isRememberPGPPassphraseOn] = true
+        }
+    }
+
+    private func importExistingKeysIntoKeychain() {
+        if let publicKey = fm.contents(atPath: Globals.pgpPublicKeyPath) {
+            Utils.addDataToKeychain(key: PGPKeyType.PUBLIC.rawValue, data: publicKey)
+        }
+        if let privateKey = fm.contents(atPath: Globals.pgpPrivateKeyPath) {
+            Utils.addDataToKeychain(key: PGPKeyType.PRIVATE.rawValue, data: privateKey)
         }
     }
     

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -190,6 +190,8 @@ public class PasswordStore {
         do {
             try KeyFileManager(keyType: PgpKeyType.PUBLIC, keyPath: Globals.pgpPublicKeyPath).importKeyAndDeleteFile()
             try KeyFileManager(keyType: PgpKeyType.PRIVATE, keyPath: Globals.pgpPrivateKeyPath).importKeyAndDeleteFile()
+            SharedDefaults.remove(.pgpPublicKeyArmor)
+            SharedDefaults.remove(.pgpPrivateKeyArmor)
             SharedDefaults[.pgpKeySource] = "file"
         } catch {
             print("MigrationError".localize(error))
@@ -838,6 +840,8 @@ public class PasswordStore {
         SharedDefaults.remove(.pgpKeySource)
         SharedDefaults.remove(.pgpPrivateKeyURL)
         SharedDefaults.remove(.pgpPublicKeyURL)
+        SharedDefaults.remove(.pgpPublicKeyArmor)
+        SharedDefaults.remove(.pgpPrivateKeyArmor)
         AppKeychain.removeContent(for: "pgpKeyPassphrase")
         AppKeychain.removeContent(for: PgpKeyType.PUBLIC.getKeychainKey())
         AppKeychain.removeContent(for: PgpKeyType.PRIVATE.getKeychainKey())

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -49,28 +49,34 @@ public class PasswordStore {
 
     public var pgpKeyPassphrase: String? {
         set {
-            Utils.addPasswordToKeychain(name: "pgpKeyPassphrase", password: newValue)
+            if newValue != nil {
+                AppKeychain.add(string: newValue!, for: "pgpKeyPassphrase")
+            }
         }
         get {
-            return Utils.getPasswordFromKeychain(name: "pgpKeyPassphrase")
+            return AppKeychain.get(for: "pgpKeyPassphrase")
         }
     }
     
     public var gitPassword: String? {
         set {
-            Utils.addPasswordToKeychain(name: "gitPassword", password: newValue)
+            if newValue != nil {
+                AppKeychain.add(string: newValue!, for: "gitPassword")
+            }
         }
         get {
-            return Utils.getPasswordFromKeychain(name: "gitPassword")
+            return AppKeychain.get(for: "gitPassword")
         }
     }
     
     public var gitSSHPrivateKeyPassphrase: String? {
         set {
-            Utils.addPasswordToKeychain(name: "gitSSHPrivateKeyPassphrase", password: newValue)
+            if newValue != nil {
+                AppKeychain.add(string: newValue!, for: "gitSSHPrivateKeyPassphrase")
+            }
         }
         get {
-            return Utils.getPasswordFromKeychain(name: "gitSSHPrivateKeyPassphrase")
+            return AppKeychain.get(for: "gitSSHPrivateKeyPassphrase")
         }
     }
     
@@ -186,10 +192,10 @@ public class PasswordStore {
 
     private func importExistingKeysIntoKeychain() {
         if let publicKey = fm.contents(atPath: Globals.pgpPublicKeyPath) {
-            Utils.addDataToKeychain(key: PGPKeyType.PUBLIC.rawValue, data: publicKey)
+            AppKeychain.add(data: publicKey, for: PGPKeyType.PUBLIC.rawValue)
         }
         if let privateKey = fm.contents(atPath: Globals.pgpPrivateKeyPath) {
-            Utils.addDataToKeychain(key: PGPKeyType.PRIVATE.rawValue, data: privateKey)
+            AppKeychain.add(data: privateKey, for: PGPKeyType.PRIVATE.rawValue)
         }
     }
     
@@ -208,7 +214,7 @@ public class PasswordStore {
     }
     
     private func initPGPKey(_ keyType: PGPKeyType) throws {
-        if let key = GopenpgpwrapperReadKey(Utils.getDataFromKeychain(for: keyType.rawValue)) {
+        if let key = GopenpgpwrapperReadKey(AppKeychain.get(for: keyType.rawValue)) {
             switch keyType {
             case .PUBLIC:
                 self.publicKey = key
@@ -222,13 +228,13 @@ public class PasswordStore {
     
     public func initPGPKey(from url: URL, keyType: PGPKeyType) throws {
         let pgpKeyData = try Data(contentsOf: url)
-        Utils.addDataToKeychain(key: keyType.rawValue, data: pgpKeyData)
+        AppKeychain.add(data: pgpKeyData, for: keyType.rawValue)
         try initPGPKey(keyType)
     }
     
     public func initPGPKey(with armorKey: String, keyType: PGPKeyType) throws {
         let pgpKeyData = armorKey.data(using: .ascii)!
-        Utils.addDataToKeychain(key: keyType.rawValue, data: pgpKeyData)
+        AppKeychain.add(data: pgpKeyData, for: keyType.rawValue)
         try initPGPKey(keyType)
     }
     
@@ -744,8 +750,8 @@ public class PasswordStore {
         try? fm.removeItem(atPath: Globals.pgpPrivateKeyPath)
         try? fm.removeItem(atPath: Globals.gitSSHPrivateKeyPath)
         
-        Utils.removeAllKeychain()
-        
+        AppKeychain.removeAllContent()
+
         deleteCoreData(entityName: "PasswordEntity")
         
         SharedDefaults.removeAll()
@@ -835,9 +841,9 @@ public class PasswordStore {
         SharedDefaults.remove(.pgpKeySource)
         SharedDefaults.remove(.pgpPrivateKeyURL)
         SharedDefaults.remove(.pgpPublicKeyURL)
-        Utils.removeKeychain(name: ".pgpKeyPassphrase")
-        Utils.removeKeychain(name: PGPKeyType.PUBLIC.rawValue)
-        Utils.removeKeychain(name: PGPKeyType.PRIVATE.rawValue)
+        AppKeychain.removeContent(for: ".pgpKeyPassphrase")
+        AppKeychain.removeContent(for: PGPKeyType.PUBLIC.rawValue)
+        AppKeychain.removeContent(for: PGPKeyType.PRIVATE.rawValue)
         publicKey = nil
         privateKey = nil
     }
@@ -876,8 +882,8 @@ public class PasswordStore {
         let publicKeyFileContent = try Data(contentsOf: publicKeyFileUrl)
         let privateKeyFileContent = try Data(contentsOf: privateKeyFileUrl)
 
-        Utils.addDataToKeychain(key: PGPKeyType.PUBLIC.rawValue, data: publicKeyFileContent)
-        Utils.addDataToKeychain(key: PGPKeyType.PRIVATE.rawValue, data: privateKeyFileContent)
+        AppKeychain.add(data: publicKeyFileContent, for: PGPKeyType.PUBLIC.rawValue)
+        AppKeychain.add(data: privateKeyFileContent, for: PGPKeyType.PRIVATE.rawValue)
 
         try fm.removeItem(at: publicKeyFileUrl)
         try fm.removeItem(at: privateKeyFileUrl)

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -848,7 +848,7 @@ public class PasswordStore {
         SharedDefaults.remove(.pgpKeySource)
         SharedDefaults.remove(.pgpPrivateKeyURL)
         SharedDefaults.remove(.pgpPublicKeyURL)
-        AppKeychain.removeContent(for: ".pgpKeyPassphrase")
+        AppKeychain.removeContent(for: "pgpKeyPassphrase")
         AppKeychain.removeContent(for: PGPKeyType.PUBLIC.rawValue)
         AppKeychain.removeContent(for: PGPKeyType.PRIVATE.rawValue)
         publicKey = nil

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -883,16 +883,16 @@ public class PasswordStore {
     }
     
     public func pgpKeyImportFromFileSharing() throws {
-        let publicKeyFileUrl = URL(fileURLWithPath: Globals.iTunesFileSharingPGPPublic)
-        let privateKeyFileUrl = URL(fileURLWithPath: Globals.iTunesFileSharingPGPPrivate)
-
-        let publicKeyFileContent = try Data(contentsOf: publicKeyFileUrl)
-        let privateKeyFileContent = try Data(contentsOf: privateKeyFileUrl)
-
+        guard let publicKeyFileContent = fm.contents(atPath: Globals.iTunesFileSharingPGPPublic) else {
+            throw AppError.ReadingFile(Globals.iTunesFileSharingPGPPublic)
+        }
         AppKeychain.add(data: publicKeyFileContent, for: PGPKeyType.PUBLIC.rawValue)
-        AppKeychain.add(data: privateKeyFileContent, for: PGPKeyType.PRIVATE.rawValue)
+        try fm.removeItem(atPath: Globals.iTunesFileSharingPGPPublic)
 
-        try fm.removeItem(at: publicKeyFileUrl)
-        try fm.removeItem(at: privateKeyFileUrl)
+        guard let privateKeyFileContent = fm.contents(atPath: Globals.iTunesFileSharingPGPPrivate) else {
+            throw AppError.ReadingFile(Globals.iTunesFileSharingPGPPrivate)
+        }
+        AppKeychain.add(data: privateKeyFileContent, for: PGPKeyType.PRIVATE.rawValue)
+        try fm.removeItem(atPath: Globals.iTunesFileSharingPGPPrivate)
     }
 }

--- a/passKitTests/Helpers/KeyFileManagerTest.swift
+++ b/passKitTests/Helpers/KeyFileManagerTest.swift
@@ -1,0 +1,49 @@
+//
+//  KeyFileManagerTest.swift
+//  passKitTests
+//
+//  Created by Danny Moesch on 01.07.19.
+//  Copyright © 2019 Bob Sun. All rights reserved.
+//
+
+import XCTest
+
+@testable import passKit
+
+class KeyFileManagerTest: XCTestCase {
+    private static let filePath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test.txt").path
+    private static let keyFileManager = KeyFileManager(keyType: .PUBLIC, keyPath: filePath) { _, _ in }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: KeyFileManagerTest.filePath)
+        super.tearDown()
+    }
+
+    func testImportKeyAndDeleteFile() throws {
+        let fileContent = "content".data(using: .ascii)
+        var storage: [String: Data] = [:]
+        let keyFileManager = KeyFileManager(keyType: .PRIVATE, keyPath: KeyFileManagerTest.filePath) { storage[$1] = $0 }
+
+        FileManager.default.createFile(atPath: KeyFileManagerTest.filePath, contents: fileContent, attributes: nil)
+        try keyFileManager.importKeyAndDeleteFile()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: KeyFileManagerTest.filePath))
+        XCTAssertTrue(storage[PgpKeyType.PRIVATE.getKeychainKey()] == fileContent)
+    }
+
+    func testErrorReadingFile() throws {
+        XCTAssertThrowsError(try KeyFileManagerTest.keyFileManager.importKeyAndDeleteFile()) {
+            XCTAssertEqual($0 as! AppError, AppError.ReadingFile("test.txt"))
+        }
+    }
+
+    func testFileExists() {
+        FileManager.default.createFile(atPath: KeyFileManagerTest.filePath, contents: nil, attributes: nil)
+
+        XCTAssertTrue(KeyFileManagerTest.keyFileManager.doesKeyFileExist())
+    }
+
+    func testFileDoesNotExist() {
+        XCTAssertFalse(KeyFileManagerTest.keyFileManager.doesKeyFileExist())
+    }
+}


### PR DESCRIPTION
This PR addresses #223, especially:
* Public and private PGP keys are stored in the Keychain instead of files.
* All data put in the Keychain is only locally available for "this" specific device after unlocking. iCloud synching is disabled.
* Existing file-based keys are automatically imported into the Keychain on first start of the app after updating. Old files are deleted.

Two smaller side effects/additions are:
* If the user triggers the removal of all keys in the app the PGP key password will now also be deleted. This did not work before.
* Since the keys are now stored only in one place (the Keychain), the import page for ASCII-armor PGP keys will show the actual keys in the according text fields. This may already address #277.