### PR TITLE
Do not show PGP and SSH keys in ASCII-armor import views

### DIFF
--- a/pass/Controllers/GitSSHKeyArmorSettingTableViewController.swift
+++ b/pass/Controllers/GitSSHKeyArmorSettingTableViewController.swift
@@ -71,7 +71,6 @@ class GitSSHKeyArmorSettingTableViewController: AutoCellHeightUITableViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        armorPrivateKeyTextView.text = AppKeychain.get(for: SshKey.PRIVATE.getKeychainKey())
         armorPrivateKeyTextView.delegate = self
 
         scanPrivateKeyCell?.textLabel?.text = "ScanPrivateKeyQrCodes".localize()

--- a/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
+++ b/pass/Controllers/PGPKeyArmorSettingTableViewController.swift
@@ -91,13 +91,6 @@ class PGPKeyArmorSettingTableViewController: AutoCellHeightUITableViewController
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        if let publicKey: Data = AppKeychain.get(for: PgpKey.PUBLIC.getKeychainKey()) {
-            armorPublicKeyTextView.text = String(data: publicKey, encoding: .ascii)
-        }
-        if let privateKey: Data = AppKeychain.get(for: PgpKey.PRIVATE.getKeychainKey()) {
-            armorPrivateKeyTextView.text = String(data: privateKey, encoding: .ascii)
-        }
-
         pgpPassphrase = passwordStore.pgpKeyPassphrase
 
         scanPublicKeyCell?.textLabel?.text = "ScanPublicKeyQrCodes".localize()


### PR DESCRIPTION
This addresses #174. It can really be seen as a security risk to show the secret keys in the app. #277 needs a dedicated export feature if it is to be implemented at all.