### PR TITLE
Save app passcode in Keychain

### DIFF
--- a/pass/Controllers/SettingsTableViewController.swift
+++ b/pass/Controllers/SettingsTableViewController.swift
@@ -159,7 +159,7 @@ class SettingsTableViewController: UITableViewController, UITabBarControllerDele
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if tableView.cellForRow(at: indexPath) == passcodeTableViewCell {
-            if SharedDefaults[.passcodeKey] != nil{
+            if passcodeLock.hasPasscode {
                 showPasscodeActionSheet()
             } else {
                 setPasscodeLock()

--- a/passKit/Helpers/DefaultsKeys.swift
+++ b/passKit/Helpers/DefaultsKeys.swift
@@ -20,6 +20,7 @@ public extension DefaultsKeys {
     static let pgpPublicKeyArmor = DefaultsKey<String?>("pgpPublicKeyArmor")
     static let pgpPrivateKeyArmor = DefaultsKey<String?>("pgpPrivateKeyArmor")
     static let gitSSHPrivateKeyArmor = DefaultsKey<String?>("gitSSHPrivateKeyArmor")
+    static let passcodeKey = DefaultsKey<String?>("passcodeKey")
 
     static let gitURL = DefaultsKey<URL?>("gitURL")
     static let gitAuthenticationMethod = DefaultsKey<String?>("gitAuthenticationMethod")
@@ -33,7 +34,6 @@ public extension DefaultsKeys {
     static let lastSyncedTime = DefaultsKey<Date?>("lastSyncedTime")
 
     static let isTouchIDOn = DefaultsKey<Bool>("isTouchIDOn", defaultValue: false)
-    static let passcodeKey = DefaultsKey<String?>("passcodeKey")
 
     static let isHideUnknownOn = DefaultsKey<Bool>("isHideUnknownOn", defaultValue: false)
     static let isHideOTPOn = DefaultsKey<Bool>("isHideOTPOn", defaultValue: false)


### PR DESCRIPTION
The passcode to unlock and use the app is currently also stored in `SharedDefaults`. It is as important as the PGP and SSH keys since if the app remembers the passphrases for the secret keys the passcode is the only layer between a bad guy and all the stored passwords. So it deserves to live in Keychain, too. 

The code changes also move an existing passcode from `SharedDefaults` into Keychain.