### PR TITLE
Fix #287.

### DIFF
--- a/go/src/gopenpgpwrapper/gopenpgpwrapper.go
+++ b/go/src/gopenpgpwrapper/gopenpgpwrapper.go
@@ -10,7 +10,11 @@ import (
 )
 
 type Key struct {
-    kr crypto.KeyRing
+    if len(k.kr.GetEntities()) > 0 {
+        return k.kr.GetEntities()[0].PrimaryKey.KeyIdShortString()
+    } else {
+        return ""
+    }
 }
 
 func (k *Key) GetKeyID() string {

--- a/go/src/gopenpgpwrapper/gopenpgpwrapper.go
+++ b/go/src/gopenpgpwrapper/gopenpgpwrapper.go
@@ -10,15 +10,15 @@ import (
 )
 
 type Key struct {
+    kr crypto.KeyRing
+}
+
+func (k *Key) GetKeyID() string {
     if len(k.kr.GetEntities()) > 0 {
         return k.kr.GetEntities()[0].PrimaryKey.KeyIdShortString()
     } else {
         return ""
     }
-}
-
-func (k *Key) GetKeyID() string {
-    return k.kr.FirstKeyID
 }
 
 func (k *Key) Encrypt(plaintext []byte, armor bool) []byte {


### PR DESCRIPTION
If the long key ID is wanted instead of the short ID replace `KeyIdShortString()` with `KeyIdString()` on l. 18 in gopenpgpwrapper.go.