### PR TITLE
Activate tests for keys with sub-keys

### DIFF
--- a/passKitTests/Crypto/CryptoFrameworkTest.swift
+++ b/passKitTests/Crypto/CryptoFrameworkTest.swift
@@ -38,9 +38,9 @@ class CryptoFrameworkTest: XCTestCase {
     private func testInternal(plainMessage: CryptoPlainMessage?, messageConverter: MessageConverter) throws {
         try [
             RSA2048,
-            //RSA2048_SUB,
+            RSA2048_SUB,
             ED25519,
-            //ED25519_SUB,
+            ED25519_SUB,
         ].forEach { keyTriple in
             let pgp = CryptoGetGopenPGP()!
             let publicKey = try pgp.buildKeyRingArmored(keyTriple.publicKey)

--- a/passKitTests/Crypto/PGPAgentTest.swift
+++ b/passKitTests/Crypto/PGPAgentTest.swift
@@ -38,7 +38,7 @@ class PGPAgentTest: XCTestCase {
             RSA2048,
             RSA2048_SUB,
             ED25519,
-            //ED25519_SUB,
+            ED25519_SUB,
         ].forEach { keyTriple in
             let keychain = DictBasedKeychain()
             let pgpAgent = PGPAgent(keyStore: keychain)


### PR DESCRIPTION
This shows that for these specific test keys ObjectivePGP is actually not needed anymore.