### PR TITLE
Wrap GopenPGP encryption errors into more understandable app errors

### DIFF
--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "RememberToRemoveKey"               = "Vergiss das Löschen des Schlüssels nicht";
 "RememberToRemoveKeyFromServer."    = "Vergiss nicht, den Schlüssel wieder vom Server zu entfernen.";
 "RemovePgpKeys"                     = "PGP-Schlüssel entfernen";
+"KeyExpiredOrIncompatibleError."    = "Der öffentliche PGP-Schlüssel ist eventuell abgelaufen oder inkompatibel mit dem privaten Schlüssel.";
+"WrongPassphraseError."             = "Das Passwort für den privaten PGP-Schlüssel ist falsch.";
 
 // App passcode
 "RemovePasscode"        = "Passcode entfernen";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -133,6 +133,8 @@
 "RememberToRemoveKeyFromServer."    = "Remember to remove the key from the server.";
 "RemovePgpKeys"                     = "Remove PGP Keys";
 "PgpCopyPublicAndPrivateKeyToPass." = "Copy your ASCII-armored public and private keys to Pass with names \"gpg_key.pub\" and \"gpg_key\" (without quotes) via iTunes. Then come back and click \"iTunes File Sharing\" to finish.";
+"KeyExpiredOrIncompatibleError."    = "PGP public key may be expired or incompatible with the private key.";
+"WrongPassphraseError."             = "Passphrase of your PGP secret key is wrong.";
 
 // App passcode
 "RemovePasscode"        = "Remove Passcode";

--- a/passKit/Helpers/AppError.swift
+++ b/passKit/Helpers/AppError.swift
@@ -17,6 +17,8 @@ public enum AppError: Error, Equatable {
     case GitCommit
     case PasswordEntity
     case PgpPublicKeyNotExist
+    case KeyExpiredOrIncompatible
+    case WrongPassphrase
     case WrongPasswordFilename
     case Decryption
     case Encryption

--- a/passKitTests/Crypto/PGPAgentTest.swift
+++ b/passKitTests/Crypto/PGPAgentTest.swift
@@ -86,7 +86,7 @@ class PGPAgentTest: XCTestCase {
         try importKeys(ED25519.publicKey, RSA2048.privateKey)
         XCTAssert(pgpAgent.isPrepared)
         XCTAssertThrowsError(try basicEncryptDecrypt(using: pgpAgent)) {
-            XCTAssert($0.localizedDescription.contains("openpgp: incorrect key"))
+            XCTAssertEqual($0 as! AppError, AppError.KeyExpiredOrIncompatible)
         }
     }
 
@@ -128,7 +128,7 @@ class PGPAgentTest: XCTestCase {
         
         // Provide the wrong passphrase.
         XCTAssertThrowsError(try basicEncryptDecrypt(using: pgpAgent, requestPassphrase: provideIncorrectPassphrase)) {
-            XCTAssert($0.localizedDescription.contains("openpgp: invalid data: private key checksum failure"))
+            XCTAssertEqual($0 as! AppError, AppError.WrongPassphrase)
         }
         XCTAssertEqual(passphraseRequestCalledCount, 2)
         


### PR DESCRIPTION
This is an idea to improve the error messages presented to the user in case of decryption errors in GopenPGP. It is not very elegant but the only way to process such errors. More of them can be added and the do-catch stuff could be extracted into a separate class later on to encapsulate the mapping and maybe extend it to ObjectivePGP too.