### PR TITLE
[DO NOT MERGE] Use the master branch of objective-git (249b64cc9301c70b11e25c5fb6339f83f040ee2e)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 github "SVProgressHUD/SVProgressHUD"
 github "radex/SwiftyUserDefaults"
-github "libgit2/objective-git"
+github "libgit2/objective-git" "master"
 github "leonbreedt/FavIcon"
 github "kishikawakatsumi/KeychainAccess"
 github "mattrubin/OneTimePassword"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.5"
 github "kishikawakatsumi/KeychainAccess" "v4.1.0"
 github "leonbreedt/FavIcon" "3.0.6"
-github "libgit2/objective-git" "0.14.2"
+github "libgit2/objective-git" "249b64cc9301c70b11e25c5fb6339f83f040ee2e"
 github "mattrubin/Base32" "1.1.2+xcode10.2"
 github "mattrubin/OneTimePassword" "3.2.0"
 github "radex/SwiftyUserDefaults" "4.0.0"


### PR DESCRIPTION
Current release is outdated.

Previously, the master of upstream can not be built. (https://github.com/libgit2/objective-git/issues/692). I don't know why it works right now.

Let's wait for upstream to figure out causes, hopefully publish a new release.