### PR TITLE
Allow HTTP for key import but ask for confirmation

### DIFF
--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -78,7 +78,7 @@
 "SetGitRepositoryUrl"                   = "Bitte gib zuerst die URL des Repositorys ein.";
 "CannotFindUsername."                   = "Der Nutzername kann nicht in der URL des Repositorys gefunden werden. Beispiel: ssh://git@server/path/to/repo.git.";
 "CheckEnteredUsername."                 = "Bitte vergleiche den eingegebenen Nutzernamen und den in der URL des Repositorys. Sie sollten übereinstimmen.";
-"UseHttps."                             = "Bitte nutze HTTPS anstatt HTTP.";
+"UseEitherHttpsOrHttp."                 = "Bitte nutze entweder HTTPS (empfohlen) oder HTTP.";
 "SpecifySchema."                        = "Bitte spezifiziere das Protokoll zur Kommunikation mit dem Git-Server in der URL (HTTPS or SSH).";
 "Overwrite?"                            = "Überschreiben?";
 "Overwrite"                             = "Überschreiben";
@@ -126,7 +126,7 @@
 "FillInPgpPassphrase."              = "Bitte gib das Passwort deines privaten PGP-Schlüssels ein.";
 "WantToSavePassphrase?"             = "Möchtest du das Passwort für spätere Entschlüsselungen speichern?";
 "CannotSavePgpKey"                  = "PGP-Schlüssel kann nicht gespeichert werden";
-"SetPgpKeyUrlFirst."                = "Bitte gib zuerst die URL des PGP-Schlüssels ein.";
+"SetPgpKeyUrlsFirst."               = "Bitte gib zuerst die URLs der PGP-Schlüssel ein.";
 "FetchingPgpKey"                    = "PGP-Schlüssel wird geladen";
 "RememberToRemoveKey"               = "Vergiss das Löschen der Schlüssel nicht";
 "RememberToRemoveKeyFromServer."    = "Vergiss nicht, die Schlüssel wieder vom Server zu entfernen.";
@@ -139,6 +139,8 @@
 "FileCannotBeImported."             = "Beim Importieren der Datei '%@' trat ein Fehler auf. Stelle bitte sicher, dass ihr Speicherort lesbar ist.";
 "RememberToRemoveKeyFromLocation."  = "Vergiss nicht, die Schlüsseldateien wieder von ihrem externen Speicherort zu entfernen.";
 "KeyFileNotSet."                    = "Es wurde nicht für beide Schlüsseltypen eine Datei angegeben.";
+"HttpNotSecure"                     = "HTTP ist nicht sicher";
+"ReallyUseHttp?"                    = "Das HTTP-Protokoll ist nicht sicher. Soll es wirklich verwendet werden, um den privaten Schlüssel zu übertragen?";
 
 // App passcode
 "RemovePasscode"        = "Passcode entfernen";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -78,7 +78,7 @@
 "SetGitRepositoryUrl"                   = "Please set the Git repository URL.";
 "CannotFindUsername."                   = "Cannot find the username in the Git repository URL. Example URL: ssh://git@server/path/to/repo.git.";
 "CheckEnteredUsername."                 = "Please check the entered username and the username in the Git repository URL. They should match.";
-"UseHttps."                             = "Please use HTTPS instead of HTTP.";
+"UseEitherHttpsOrHttp."                 = "Please use either HTTPS (recommended) or HTTP.";
 "SpecifySchema."                        = "Please specify the scheme of the Git repository URL (HTTPS or SSH).";
 "Overwrite?"                            = "Overwrite?";
 "Overwrite"                             = "Overwrite";
@@ -126,7 +126,7 @@
 "FillInPgpPassphrase."              = "Please fill in the passphrase of your PGP secret key.";
 "WantToSavePassphrase?"             = "Do you want to save the passphrase for later decryption?";
 "CannotSavePgpKey"                  = "Cannot Save PGP Key";
-"SetPgpKeyUrlFirst."                = "Please set PGP key URL first.";
+"SetPgpKeyUrlsFirst."               = "Please set PGP key URLs first.";
 "FetchingPgpKey"                    = "Fetching PGP Key";
 "RememberToRemoveKey"               = "Remember to Remove the Keys";
 "RememberToRemoveKeyFromServer."    = "Remember to remove the keys from the server.";
@@ -139,6 +139,8 @@
 "FileCannotBeImported."             = "An error occurred importing the file '%@'. Please make sure its location is readable.";
 "RememberToRemoveKeyFromLocation."  = "Remember to remove the key files from their external locations.";
 "KeyFileNotSet."                    = "At least for one key type there is no file specified.";
+"HttpNotSecure"                     = "HTTP Is Not Secure";
+"ReallyUseHttp?"                    = "The HTTP protocol is not secure. Do you really want to use it to transfer the private key file?";
 
 // App passcode
 "RemovePasscode"        = "Remove Passcode";


### PR DESCRIPTION
According to the argument in #320 that HTTP might be okay in safe environments (e.g. home networks), this PR allows HTTP for public keys and also for private keys. The app will ask for confirmation if the private key is referenced by HTTP, though, as an import could potentially be harmful.