### PR TITLE
Use forked ObjectivePGP

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '10.2'
 use_frameworks!
 
 def pods
-  pod 'ObjectivePGP', :git => 'https://github.com/krzyzanowskim/ObjectivePGP.git', :tag => '0.15.0'
+  pod 'ObjectivePGP', :git => 'https://github.com/mssun/ObjectivePGP.git', :tag => '0.15.1'
 end
 
 target 'passKit' do


### PR DESCRIPTION
Start to use forked ObjectivePGP (https://github.com/mssun/ObjectivePGP/tree/passforios).

I also merged https://github.com/krzyzanowskim/ObjectivePGP/pull/160. I saw some crash logs via TestFlight caused by this invalid/unsupported packet.

@SimplyDanny, what do you think?