### PR TITLE
Some UI fixes in password generation settings

### DIFF
--- a/pass/Controllers/PasswordEditorTableViewController.swift
+++ b/pass/Controllers/PasswordEditorTableViewController.swift
@@ -207,6 +207,17 @@ class PasswordEditorTableViewController: UITableViewController {
         return 44
     }
 
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        switch tableData[indexPath.section][indexPath.row][PasswordEditorCellKey.type] as! PasswordEditorCellType {
+        case .passwordLengthCell, .passwordGroupsCell:
+            return 42
+        case .passwordUseDigitsCell, .passwordVaryCasesCell, .passwordUseSpecialSymbols, .passwordFlavorCell:
+            return 42
+        default:
+            return UITableView.automaticDimension
+        }
+    }
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return tableData.count
     }

--- a/pass/Views/SwitchTableViewCell.xib
+++ b/pass/Views/SwitchTableViewCell.xib
@@ -27,6 +27,7 @@
                     </label>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uza-Tn-Tvb">
                         <rect key="frame" x="263" y="20" width="51" height="34"/>
+                        <color key="onTintColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <action selector="switchValueChanged:" destination="ZfB-GH-J5H" eventType="valueChanged" id="7M4-rU-jkI"/>
                         </connections>

--- a/pass/Views/SwitchTableViewCell.xib
+++ b/pass/Views/SwitchTableViewCell.xib
@@ -26,7 +26,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uza-Tn-Tvb">
-                        <rect key="frame" x="263" y="20" width="51" height="34"/>
+                        <rect key="frame" x="256" y="21.5" width="51" height="31"/>
                         <color key="onTintColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <action selector="switchValueChanged:" destination="ZfB-GH-J5H" eventType="valueChanged" id="7M4-rU-jkI"/>
@@ -34,9 +34,8 @@
                     </switch>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="uza-Tn-Tvb" firstAttribute="trailing" secondItem="yOK-hg-p5T" secondAttribute="trailingMargin" constant="7" id="AI4-cq-01M"/>
-                    <constraint firstAttribute="bottom" secondItem="uza-Tn-Tvb" secondAttribute="bottom" constant="20" symbolic="YES" id="JHm-gr-hAx"/>
-                    <constraint firstItem="uza-Tn-Tvb" firstAttribute="top" secondItem="yOK-hg-p5T" secondAttribute="top" constant="20" symbolic="YES" id="YPW-8k-up9"/>
+                    <constraint firstItem="uza-Tn-Tvb" firstAttribute="trailing" secondItem="yOK-hg-p5T" secondAttribute="trailingMargin" id="AI4-cq-01M"/>
+                    <constraint firstItem="uza-Tn-Tvb" firstAttribute="centerY" secondItem="ZcB-yD-ZwW" secondAttribute="centerY" id="YPW-8k-up9"/>
                     <constraint firstItem="ZcB-yD-ZwW" firstAttribute="leading" secondItem="yOK-hg-p5T" secondAttribute="leadingMargin" id="lFa-jJ-Jc7"/>
                     <constraint firstAttribute="bottomMargin" secondItem="ZcB-yD-ZwW" secondAttribute="bottom" id="nMt-uF-ECF"/>
                     <constraint firstItem="ZcB-yD-ZwW" firstAttribute="top" secondItem="yOK-hg-p5T" secondAttribute="topMargin" id="wJh-hO-b3q"/>

--- a/passKit/Passwords/PasswordGenerator.swift
+++ b/passKit/Passwords/PasswordGenerator.swift
@@ -83,17 +83,17 @@ public struct PasswordGenerator: Codable {
     private func generateRandom() -> String {
         let currentCharacters = characters
         if groups > 1, isAcceptable(groups: groups) {
-            return selectRandomly(count: length - groups + 1, from: currentCharacters)
+            return selectRandomly(count: limitedLength - groups + 1, from: currentCharacters)
                 .slices(count: UInt(groups))
                 .map { String($0) }
                 .joined(separator: "-")
         }
-        return String(selectRandomly(count: length, from: currentCharacters))
+        return String(selectRandomly(count: limitedLength, from: currentCharacters))
     }
 
     private func generateXkcd() -> String {
         let currentDelimiters = delimiters
-        return getRandomDelimiter(from: currentDelimiters) + (0 ..< length)
+        return getRandomDelimiter(from: currentDelimiters) + (0 ..< limitedLength)
             .map { _ in getRandomWord() + getRandomDelimiter(from: currentDelimiters) }
             .joined()
     }

--- a/passKitTests/Passwords/PasswordGeneratorTest.swift
+++ b/passKitTests/Passwords/PasswordGeneratorTest.swift
@@ -55,6 +55,26 @@ class PasswordGeneratorTest: XCTestCase {
         XCTAssertFalse(generator.isAcceptable(groups: 4))
     }
 
+    func testRandomGroupsCount() {
+        [
+            PasswordGenerator(length: 15, groups: 4),
+            PasswordGenerator(length: 24, groups: 5),
+            PasswordGenerator(length: 63, groups: 8),
+        ].forEach { generator in
+            XCTAssertEqual(generator.generate().split(separator: "-").count, generator.groups)
+        }
+    }
+
+    func testXKCDWordsCount() {
+        [
+            PasswordGenerator(flavor: .xkcd, length: 4, useSpecialSymbols: false),
+            PasswordGenerator(flavor: .xkcd, length: 8, useSpecialSymbols: false),
+            PasswordGenerator(flavor: .xkcd, length: 1, useSpecialSymbols: false),
+        ].forEach { generator in
+            XCTAssertEqual(generator.generate().split(whereSeparator: { "0123456789".contains($0) }).count, generator.limitedLength)
+        }
+    }
+
     func testRandomPasswordLength() {
         [
             PasswordGenerator(),


### PR DESCRIPTION
This PR contains the fixes for the remarks in #359 as well as some more (UI) tweaks. The password properties selection now looks like:

![password-generation-ui](https://user-images.githubusercontent.com/16365760/76153506-327f7f00-60cd-11ea-8f99-2f0b2f288497.png)

Reducing the size of the properties cells causes a warning in Xcode about unsatisfied constraints. It is hard for me to figure out what is wrong and how it can be fixed. Maybe the approach of setting the cell height manually is not correct. How can this be improved?

