### PR TITLE
Reload password list when opening the app

### DIFF
--- a/pass/Controllers/PasswordsViewController.swift
+++ b/pass/Controllers/PasswordsViewController.swift
@@ -249,6 +249,8 @@ class PasswordsViewController: UIViewController, UITableViewDataSource, UITableV
         // reset the data table if the disaply settings have been changed
         NotificationCenter.default.addObserver(self, selector: #selector(actOnReloadTableViewRelatedNotification), name: .passwordDisplaySettingChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(actOnSearchNotification), name: .passwordSearch, object: nil)
+        // A Siri shortcut can change the state of the app in the background. Hence, reload when opening the app.
+        NotificationCenter.default.addObserver(self, selector: #selector(actOnReloadTableViewRelatedNotification), name: UIApplication.willEnterForegroundNotification, object: nil)
 
         // listen to the swipe back guesture
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(self.respondToSwipeGesture))


### PR DESCRIPTION
Reason is that the state of the repository could have been changed in the background by the Siri shortcut. If the update does not happen, uncommitted changes could be shown which are actually not there anymore.