### PR TITLE
Some fixes

### DIFF
--- a/pass/Controllers/GitRepositorySettingsTableViewController.swift
+++ b/pass/Controllers/GitRepositorySettingsTableViewController.swift
@@ -227,10 +227,10 @@ class GitRepositorySettingsTableViewController: UITableViewController {
                 DispatchQueue.main.async {
                     SVProgressHUD.showSuccess(withStatus: "Imported".localize())
                     SVProgressHUD.dismiss(withDelay: 1)
+                    Defaults.gitSSHKeySource = type(of: keyImporter).keySource
+                    self.gitAuthenticationMethod = .key
+                    self.sshLabel?.isEnabled = true
                 }
-                Defaults.gitSSHKeySource = type(of: keyImporter).keySource
-                self.gitAuthenticationMethod = .key
-                self.sshLabel?.isEnabled = true
             } catch {
                 Utils.alert(title: "Error".localize(), message: error.localizedDescription, controller: self)
             }

--- a/pass/Controllers/KeyImporter.swift
+++ b/pass/Controllers/KeyImporter.swift
@@ -14,6 +14,8 @@ protocol KeyImporter {
 
     static var label: String { get }
 
+    static var isCurrentKeySource: Bool { get }
+
     static var menuLabel: String { get }
 
     func isReadyToUse() -> Bool

--- a/passShortcuts/Info.plist
+++ b/passShortcuts/Info.plist
@@ -25,9 +25,13 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>IntentsRestrictedWhileLocked</key>
-			<array/>
+			<array>
+				<string>SyncRepositoryIntent</string>
+			</array>
 			<key>IntentsRestrictedWhileProtectedDataUnavailable</key>
-			<array/>
+			<array>
+				<string>SyncRepositoryIntent</string>
+			</array>
 			<key>IntentsSupported</key>
 			<array>
 				<string>SyncRepositoryIntent</string>


### PR DESCRIPTION
This PR contains some small fixes.

Some remark about the restriction of the shortcut: To sync the repository with the server the shortcut needs access to the keychain for authentication. This is not possible if the device is locked. Therefore, the shortcut can actually not be used automatically. That's a pity. Nevertheless,  it might be useful to embed it into other workflows or "non-automatic automations". 