### PR TITLE
Inform the user about a failed push

### DIFF
--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "FileNotFoundError."                    = "Die Datei '%@' kann nicht gelesen werden.";
 "PasswordDuplicatedError."              = "Passwort kann nicht hinzugefügt werden; es existiert bereits.";
 "GitResetError."                        = "Der zuletzt synchronisierte Commit kann nicht identifiziert werden.";
+"GitCreateSignatureError."              = "Es konnte keine valide Signatur für den Author/Committer angelegt werden.";
+"GitPushNotSuccessfulError."            = "Die Übertragung der lokalen Änderungen war nicht erfolgreich. Stelle bitte sicher, dass auf dem Remote-Repository alle Änderungen commitet sind.";
 "WrongPasswordFilenameError."           = "Schreiben der Passwort-Datei nicht möglich .";
 "DecryptionError."                      = "Passwort kann nicht entschlüsselt werden.";
 "EncodingError."                        = "Schlüssel ist nicht in ASCII kodiert.";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "FileNotFoundError."                    = "File '%@' cannot be read.";
 "PasswordDuplicatedError."              = "Cannot add the password; password is duplicated.";
 "GitResetError."                        = "Cannot identify the latest synced commit.";
+"GitCreateSignatureError."              = "Cannot create a valid author/committer signature.";
+"GitPushNotSuccessfulError."            = "Pushing local changes was not successful. Make sure there are no uncommitted changes on the remote repository.";
 "WrongPasswordFilenameError."           = "Cannot write to the password file.";
 "DecryptionError."                      = "Cannot decrypt password.";
 "EncodingError."                        = "Key is not ASCII encoded.";

--- a/passKit/Helpers/AppError.swift
+++ b/passKit/Helpers/AppError.swift
@@ -14,7 +14,8 @@ public enum AppError: Error, Equatable {
     case ReadingFile(_: String)
     case PasswordDuplicated
     case GitReset
-    case GitCommit
+    case GitCreateSignature
+    case GitPushNotSuccessful
     case PasswordEntity
     case PgpPublicKeyNotFound(keyID: String)
     case PgpPrivateKeyNotFound(keyID: String)


### PR DESCRIPTION
In case there are uncommitted changes in the remote repository the push ran through successfully but there were still unpushed changes in the app. This change notfies the user about this situation. Strangely, the push method from Objective-Git does not inform about this, although the command line Git does. Thus, the check for the number of local changes is used after the push operation, which can actually have several reasons. Important is that there is at least some hint, though.