### PR TITLE
Use correct bundle ID for extensions in beta app

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -1881,6 +1881,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_SWIFT_FLAGS = "-D BETA";
 				PRODUCT_BUNDLE_IDENTIFIER = me.mssun.passforiosbeta;
 				PRODUCT_NAME = "Pass Beta";
 				SDKROOT = iphoneos;

--- a/passKit/Helpers/Globals.swift
+++ b/passKit/Helpers/Globals.swift
@@ -10,7 +10,14 @@ import Foundation
 import UIKit
 
 public final class Globals {
-    public static let bundleIdentifier = Bundle.main.bundleIdentifier ?? "me.mssun.passforios"
+    public static let bundleIdentifier: String = {
+        #if BETA
+            return "me.mssun.passforiosbeta"
+        #else
+            return "me.mssun.passforios"
+        #endif
+    }()
+
     public static let groupIdentifier = "group." + bundleIdentifier
     public static let passKitBundleIdentifier = bundleIdentifier + ".passKit"
 


### PR DESCRIPTION
This claims to be a fix for #404. The extensions crashes because `Bundle.main.bundleIdentifier` returns `"me.mssun.passforios.auto-fill-credential-extension"` while `"me.mssun.passforiosbeta"` is expected to access the shared group container `FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)`.

Using a compiler flag might not be the most elegant fix. I'm open for better solutions. 🙂 