### PR TITLE
Fix #424: Escape question mark '?'

### DIFF
--- a/passKit/Extensions/String+Utilities.swift
+++ b/passKit/Extensions/String+Utilities.swift
@@ -12,7 +12,7 @@ public extension String {
     }
 
     func stringByAddingPercentEncodingForRFC3986() -> String? {
-        let unreserved = "-._~/?"
+        let unreserved = "-._~/"
         var allowed = CharacterSet.alphanumerics
         allowed.insert(charactersIn: unreserved)
         return addingPercentEncoding(withAllowedCharacters: allowed)

--- a/passKitTests/Extensions/String+UtilitiesTest.swift
+++ b/passKitTests/Extensions/String+UtilitiesTest.swift
@@ -23,8 +23,8 @@ class StringUtilitiesTest: XCTestCase {
 
     func testStringByAddingPercentEncodingForRFC3986() {
         [
-            ("!#$&'()*+,/:;=?@[]^", "%21%23%24%26%27%28%29%2A%2B%2C/%3A%3B%3D?%40%5B%5D%5E"),
-            ("-._~/?", "-._~/?"),
+            ("!#$&'()*+,/:;=?@[]^", "%21%23%24%26%27%28%29%2A%2B%2C/%3A%3B%3D%3F%40%5B%5D%5E"),
+            ("-._~/", "-._~/"),
             ("A*b!c", "A%2Ab%21c"),
         ].forEach { unencoded, encoded in
             XCTAssertEqual(unencoded.stringByAddingPercentEncodingForRFC3986(), encoded)


### PR DESCRIPTION
It would otherwise be interpreted as the beginning of the query part in an URL.