### PR TITLE
Add Carthage compatibility with Xcode 12.1

### DIFF
--- a/wcarthage
+++ b/wcarthage
@@ -1,18 +1,19 @@
-#!/bin/sh -e
+# This script is a work around for Carthage bug with Xcode 12.
+# Source : https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md
 
-echo "Applying Xcode 12 workaround ..."
+set -euo pipefail
 
-xcconfig="/tmp/xc12-carthage.xcconfig"
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' > $xcconfig
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
-echo 'ONLY_ACTIVE_ARCH=NO' >> $xcconfig
-echo 'VALID_ARCHS = $(inherited) x86_64' >> $xcconfig
+
 export XCODE_XCCONFIG_FILE="$xcconfig"
-
-echo "Workaround has been applied. xcconfig file can be found at '$XCODE_XCCONFIG_FILE'."
-
-echo "Running Carthage ..."
-
-carthage $@
-
+carthage "$@"


### PR DESCRIPTION
Changed `wcarthage` to [the script recommended by Carthage](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md), which works with Xcode 12.1 
They advise to put this script in your PATH, so we could remove this file altogether, and refer to this script in the README