### PR TITLE
Fix warning by removing the argument 'entersReaderIfAvailable'

### DIFF
--- a/pass/Controllers/BasicStaticTableViewController.swift
+++ b/pass/Controllers/BasicStaticTableViewController.swift
@@ -105,7 +105,7 @@ class BasicStaticTableViewController: UITableViewController, MFMailComposeViewCo
                     Utils.alert(title: alertTitle, message: alertMessage, controller: self, completion: nil)
                 }
             case "http", "https":
-                let svc = SFSafariViewController(url: URL(string: link)!, entersReaderIfAvailable: false)
+                let svc = SFSafariViewController(url: URL(string: link)!)
                 present(svc, animated: true, completion: nil)
             default:
                 break

--- a/pass/Controllers/OpenSourceComponentsTableViewController.swift
+++ b/pass/Controllers/OpenSourceComponentsTableViewController.swift
@@ -73,7 +73,7 @@ class OpenSourceComponentsTableViewController: BasicStaticTableViewController {
     @objc
     func actOnDetailDisclosureButton(_ sender: Any?) {
         if let link = sender as? String, let url = URL(string: link) {
-            let svc = SFSafariViewController(url: url, entersReaderIfAvailable: false)
+            let svc = SFSafariViewController(url: url)
             present(svc, animated: true)
         }
     }


### PR DESCRIPTION
The constructor is deprecated since iOS 11. Xcode shows a warning.