### PR TITLE
Improve lock view behavior in extensions and their password suggestions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -221,6 +221,8 @@ closure_body_length:
 identifier_name:
   excluded: ["id", "to", "Defaults"]
   allowed_symbols: ["_"]
+multiline_arguments:
+  only_enforce_after_first_closure_on_first_line: true
 type_name:
   max_length: 50
 trailing_closure:

--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		30A69948240EED5E00B7D967 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A69947240EED5E00B7D967 /* IntentHandler.swift */; };
 		30A6995D240EED5F00B7D967 /* passShortcuts.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 30A69945240EED5E00B7D967 /* passShortcuts.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		30A86F95230F237000F821A4 /* CryptoFrameworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A86F94230F237000F821A4 /* CryptoFrameworkTest.swift */; };
+		30B00F5526D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B00F5426D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift */; };
+		30B00F5626D597A8004DAC61 /* PasscodeLockViewControllerForExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B00F5426D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift */; };
 		30B04860209A5141001013CA /* PasswordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B0485F209A5141001013CA /* PasswordTest.swift */; };
 		30B4C7BA24084AAA008B86F7 /* PasswordGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B4C7B924084AAA008B86F7 /* PasswordGenerator.swift */; };
 		30BAC8C622E3BAAF00438475 /* TestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BAC8C422E3BAAF00438475 /* TestBase.swift */; };
@@ -350,6 +352,7 @@
 		30A6994F240EED5F00B7D967 /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
 		30A69968240EF52E00B7D967 /* SyncRepositoryIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepositoryIntentHandler.swift; sourceTree = "<group>"; };
 		30A86F94230F237000F821A4 /* CryptoFrameworkTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoFrameworkTest.swift; sourceTree = "<group>"; };
+		30B00F5426D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeLockViewControllerForExtension.swift; sourceTree = "<group>"; };
 		30B0485F209A5141001013CA /* PasswordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTest.swift; sourceTree = "<group>"; };
 		30B4C7B924084AAA008B86F7 /* PasswordGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordGenerator.swift; sourceTree = "<group>"; };
 		30BAC8C422E3BAAF00438475 /* TestBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBase.swift; sourceTree = "<group>"; };
@@ -795,6 +798,7 @@
 				30697C5221F63E0B0064FCAC /* CredentialProviderViewController.swift */,
 				9A55C184259E8C5600FA8FD9 /* PasswordsViewController.swift */,
 				30697C5121F63E0B0064FCAC /* PasscodeExtensionDisplay.swift */,
+				30B00F5426D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1590,6 +1594,7 @@
 				9A8F9ECC259ECB410027CE15 /* PasswordSelectionDelegate.swift in Sources */,
 				30697C5421F63E0B0064FCAC /* CredentialProviderViewController.swift in Sources */,
 				9A55C185259E8C5600FA8FD9 /* PasswordsViewController.swift in Sources */,
+				30B00F5526D59562004DAC61 /* PasscodeLockViewControllerForExtension.swift in Sources */,
 				9A5D06F525A56F0E00FA59D4 /* PasswordTableViewCell.swift in Sources */,
 				9A8F9EBD259EA4C50027CE15 /* PasswordsTableDataSource.swift in Sources */,
 				30697C5321F63E0B0064FCAC /* PasscodeExtensionDisplay.swift in Sources */,
@@ -1683,6 +1688,7 @@
 				9AFC882725B53BF4008D6060 /* PasswordDecryptor.swift in Sources */,
 				30697C4B21F63D460064FCAC /* ExtensionViewController.swift in Sources */,
 				9A58661B25AAA946006719C2 /* PasswordsTableDataSource.swift in Sources */,
+				30B00F5626D597A8004DAC61 /* PasscodeLockViewControllerForExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/pass/Services/PasswordNavigationDataSource.swift
+++ b/pass/Services/PasswordNavigationDataSource.swift
@@ -68,7 +68,7 @@ class PasswordNavigationDataSource: NSObject, UITableViewDataSource {
         }
 
         filteredSections = sections.map { section in
-            let entries = section.entries.filter { $0.match(text) }
+            let entries = section.entries.filter { $0.matches(text) }
             return Section(title: section.title, entries: entries)
         }
         .filter { !$0.entries.isEmpty }

--- a/passAutoFillExtension/Controllers/CredentialProviderViewController.swift
+++ b/passAutoFillExtension/Controllers/CredentialProviderViewController.swift
@@ -60,14 +60,11 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     }
 
     override func prepareInterfaceToProvideCredential(for credentialIdentity: ASPasswordCredentialIdentity) {
-        guard let identifier = credentialIdentity.recordIdentifier else {
-            return
+        passcodelock.presentPasscodeLockIfNeeded(self) {
+            self.view.isHidden = true
+        } after: { [unowned self] in
+            self.credentialProvider.credentials(for: credentialIdentity)
         }
-        passcodelock.presentPasscodeLockIfNeeded(self, after: { [unowned self] in
-            self.credentialProvider.identifier = credentialIdentity.serviceIdentifier
-            self.passwordsViewController.navigationItem.prompt = identifier
-            self.passwordsViewController.showPasswordsWithSuggestion(matching: identifier)
-        })
     }
 
     @objc

--- a/passAutoFillExtension/Controllers/CredentialProviderViewController.swift
+++ b/passAutoFillExtension/Controllers/CredentialProviderViewController.swift
@@ -39,7 +39,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         credentialProvider.identifier = serviceIdentifiers.first
         let url = serviceIdentifiers.first.flatMap { URL(string: $0.identifier) }
         passwordsViewController.navigationItem.prompt = url?.host
-        passwordsViewController.showPasswordsWithSuggstion(matching: url?.host ?? "")
+        passwordsViewController.showPasswordsWithSuggestion(matching: url?.host ?? "")
     }
 
     override func provideCredentialWithoutUserInteraction(for credentialIdentity: ASPasswordCredentialIdentity) {
@@ -57,7 +57,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         }
         credentialProvider.identifier = credentialIdentity.serviceIdentifier
         passwordsViewController.navigationItem.prompt = identifier
-        passwordsViewController.showPasswordsWithSuggstion(matching: identifier)
+        passwordsViewController.showPasswordsWithSuggestion(matching: identifier)
     }
 
     @objc

--- a/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
+++ b/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
@@ -19,15 +19,12 @@ class PasscodeExtensionDisplay {
     }
 
     // present the passcode lock view if passcode is set and the view controller is not presented
-    func presentPasscodeLockIfNeeded(_ extensionVC: UIViewController) {
-        extensionVC.view.isHidden = true
-        guard PasscodeLock.shared.hasPasscode else {
-            extensionVC.view.isHidden = false
-            return
-        }
-        passcodeLockVC.modalPresentationStyle = .fullScreen
-        extensionVC.parent?.present(passcodeLockVC, animated: false) {
-            extensionVC.view.isHidden = false
+    func presentPasscodeLockIfNeeded(_ sender: UIViewController, before: (() -> Void)? = nil, after: (() -> Void)? = nil) {
+        if PasscodeLock.shared.hasPasscode {
+            before?()
+            passcodeLockVC.successCallback = after
+            passcodeLockVC.modalPresentationStyle = .fullScreen
+            sender.parent?.present(passcodeLockVC, animated: false)
         }
     }
 }

--- a/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
+++ b/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
@@ -1,35 +1,12 @@
 //
-//  PasscodeLockDisplay.swift
-//  pass
+//  PasscodeExtensionDisplay.swift
+//  passAutoFillExtension
 //
 //  Created by Yishi Lin on 14/6/17.
 //  Copyright © 2017 Bob Sun. All rights reserved.
 //
 
-import AuthenticationServices
-import Foundation
 import passKit
-
-// cancel means cancel the extension
-class PasscodeLockViewControllerForExtension: PasscodeLockViewController {
-    var originalExtensionContext: NSExtensionContext!
-
-    convenience init(extensionContext: NSExtensionContext) {
-        self.init()
-        self.originalExtensionContext = extensionContext
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        cancelButton?.removeTarget(nil, action: nil, for: .allEvents)
-        cancelButton?.addTarget(self, action: #selector(cancelExtension), for: .touchUpInside)
-    }
-
-    @objc
-    func cancelExtension() {
-        originalExtensionContext.cancelRequest(withError: NSError(domain: "PassExtension", code: 0))
-    }
-}
 
 class PasscodeExtensionDisplay {
     private let passcodeLockVC: PasscodeLockViewControllerForExtension

--- a/passAutoFillExtension/Controllers/PasscodeLockViewControllerForExtension.swift
+++ b/passAutoFillExtension/Controllers/PasscodeLockViewControllerForExtension.swift
@@ -1,0 +1,30 @@
+//
+//  PasscodeLockViewControllerForExtension.swift
+//  passAutoFillExtension
+//
+//  Created by Danny Moesch on 24.08.21.
+//  Copyright © 2021 Bob Sun. All rights reserved.
+//
+
+import passKit
+
+class PasscodeLockViewControllerForExtension: PasscodeLockViewController {
+    var originalExtensionContext: NSExtensionContext!
+
+    convenience init(extensionContext: NSExtensionContext) {
+        self.init()
+        self.originalExtensionContext = extensionContext
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        cancelButton?.removeTarget(nil, action: nil, for: .allEvents)
+        // cancel means cancel the extension
+        cancelButton?.addTarget(self, action: #selector(cancelExtension), for: .touchUpInside)
+    }
+
+    @objc
+    func cancelExtension() {
+        originalExtensionContext.cancelRequest(withError: NSError(domain: "PassExtension", code: 0))
+    }
+}

--- a/passAutoFillExtension/Controllers/PasswordsViewController.swift
+++ b/passAutoFillExtension/Controllers/PasswordsViewController.swift
@@ -43,7 +43,7 @@ class PasswordsViewController: UIViewController {
         tableView.dataSource = dataSource
     }
 
-    func showPasswordsWithSuggstion(matching text: String) {
+    func showPasswordsWithSuggestion(matching text: String) {
         dataSource.showTableEntriesWithSuggestion(matching: text)
         tableView.reloadData()
     }

--- a/passAutoFillExtension/Services/PasswordsTableDataSource.swift
+++ b/passAutoFillExtension/Services/PasswordsTableDataSource.swift
@@ -61,7 +61,7 @@ class PasswordsTableDataSource: NSObject, UITableViewDataSource {
             return
         }
 
-        filteredPasswordsTableEntries = passwordTableEntries.filter { $0.match(text) }
+        filteredPasswordsTableEntries = passwordTableEntries.filter { $0.matches(text) }
         showSuggestion = false
     }
 
@@ -73,7 +73,7 @@ class PasswordsTableDataSource: NSObject, UITableViewDataSource {
         }
 
         for entry in passwordTableEntries {
-            if entry.match(text) {
+            if entry.matches(text) {
                 suggestedPasswordsTableEntries.append(entry)
             } else {
                 otherPasswordsTableEntries.append(entry)

--- a/passExtension/Controllers/ExtensionViewController.swift
+++ b/passExtension/Controllers/ExtensionViewController.swift
@@ -59,7 +59,7 @@ class ExtensionViewController: UIViewController {
 
         func completeTask(_ text: String?) {
             DispatchQueue.main.async {
-                self.passwordsViewController.showPasswordsWithSuggstion(matching: text ?? "")
+                self.passwordsViewController.showPasswordsWithSuggestion(matching: text ?? "")
                 self.passwordsViewController.navigationItem.prompt = text
             }
         }

--- a/passKit/Models/PasswordTableEntry.swift
+++ b/passKit/Models/PasswordTableEntry.swift
@@ -23,7 +23,7 @@ public class PasswordTableEntry: NSObject {
         self.categoryText = entity.getCategoryText()
     }
 
-    public func match(_ searchText: String) -> Bool {
+    public func matches(_ searchText: String) -> Bool {
         PasswordTableEntry.match(nameWithCategory: passwordEntity.nameWithCategory, searchText: searchText)
     }
 


### PR DESCRIPTION
Please see the commit descriptions for details. The changes further improve #484 and the password suggestion. It should especially fix #467 since `prepareInterfaceToProvideCredential` now provides a matching password. It must not show the password list. 