### PR TITLE
Already show password list in background before dismissing lock view

### DIFF
--- a/passKit/Controllers/PasscodeLockViewController.swift
+++ b/passKit/Controllers/PasscodeLockViewController.swift
@@ -136,24 +136,24 @@ open class PasscodeLockViewController: UIViewController, UITextFieldDelegate {
         }
     }
 
-    internal func dismissPasscodeLock(completionHandler: (() -> Void)? = nil) {
+    private func dismissPasscodeLock(completionHandler: (() -> Void)? = nil) {
         // clean up the textfield
         DispatchQueue.main.async {
             self.passcodeTextField?.text = ""
         }
+
+        completionHandler?()
 
         // pop
         if presentingViewController?.presentedViewController == self {
             // if presented as modal
             dismiss(animated: true) { [weak self] in
                 self?.dismissCompletionCallback?()
-                completionHandler?()
             }
         } else {
             // if pushed in a navigation controller
             _ = navigationController?.popViewController(animated: true)
             dismissCompletionCallback?()
-            completionHandler?()
         }
     }
 


### PR DESCRIPTION
Currently it's like:

  1) Lock view is presented
  2) Authenticate
  3) Lock view disappears
  4) Browser is shown briefly
  5) Extension shows password list

This change skips step 4.