### PR TITLE
Use the most recent version of Go in build

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,8 +9,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Installing packages
       run: |
-        brew install libtool automake cmake carthage go@1.14 swiftformat openssl libssh2
+        brew install libtool automake cmake carthage swiftformat openssl libssh2
         brew install swiftlint || brew link --overwrite swiftlint
+        brew install go || brew link --overwrite go
         gem install bundler
     - uses: actions/cache@v2
       id: carthage-cache
@@ -45,8 +46,6 @@ jobs:
         ./scripts/wcarthage bootstrap --platform iOS --no-use-binaries --cache-builds
     - name: GopenPGP
       if: steps.gopenpgp-cache.outputs.cache-hit != 'true'
-      run: |
-        export PATH="/usr/local/opt/go@1.14/bin:$PATH"
-        ./scripts/gopenpgp_build.sh
+      run: ./scripts/gopenpgp_build.sh
     - name: Testing
       run: bundle exec fastlane test


### PR DESCRIPTION
According to 93954f3becf0c6c73e9d02f1a36599ab98e6cc5e version 1.14 is not specifically required anymore.