### PR TITLE
Check cloned repository for .gpg-id file

### DIFF
--- a/pass/Controllers/GitRepositorySettingsTableViewController.swift
+++ b/pass/Controllers/GitRepositorySettingsTableViewController.swift
@@ -194,27 +194,7 @@ class GitRepositorySettingsTableViewController: UITableViewController, PasswordA
                 )
 
                 SVProgressHUD.dismiss {
-                    let savePassphraseAlert: UIAlertController = {
-                        let alert = UIAlertController(title: "Done".localize(), message: "WantToSaveGitCredential?".localize(), preferredStyle: .alert)
-                        alert.addAction(
-                            UIAlertAction(title: "No".localize(), style: .default) { _ in
-                                Defaults.isRememberGitCredentialPassphraseOn = false
-                                self.passwordStore.gitPassword = nil
-                                self.passwordStore.gitSSHPrivateKeyPassphrase = nil
-                                self.performSegue(withIdentifier: "saveGitServerSettingSegue", sender: self)
-                            }
-                        )
-                        alert.addAction(
-                            UIAlertAction(title: "Yes".localize(), style: .destructive) { _ in
-                                Defaults.isRememberGitCredentialPassphraseOn = true
-                                self.performSegue(withIdentifier: "saveGitServerSettingSegue", sender: self)
-                            }
-                        )
-                        return alert
-                    }()
-                    DispatchQueue.main.async {
-                        self.present(savePassphraseAlert, animated: true)
-                    }
+                    self.savePassphraseAndSegue()
                 }
             } catch {
                 SVProgressHUD.dismiss {
@@ -228,6 +208,31 @@ class GitRepositorySettingsTableViewController: UITableViewController, PasswordA
                     }
                 }
             }
+        }
+    }
+
+    private func savePassphraseAndSegue() {
+        let savePassphraseAlert = UIAlertController(
+            title: "Done".localize(),
+            message: "WantToSaveGitCredential?".localize(),
+            preferredStyle: .alert
+        )
+        savePassphraseAlert.addAction(
+            UIAlertAction(title: "No".localize(), style: .default) { _ in
+                Defaults.isRememberGitCredentialPassphraseOn = false
+                self.passwordStore.gitPassword = nil
+                self.passwordStore.gitSSHPrivateKeyPassphrase = nil
+                self.performSegue(withIdentifier: "saveGitServerSettingSegue", sender: self)
+            }
+        )
+        savePassphraseAlert.addAction(
+            UIAlertAction(title: "Yes".localize(), style: .destructive) { _ in
+                Defaults.isRememberGitCredentialPassphraseOn = true
+                self.performSegue(withIdentifier: "saveGitServerSettingSegue", sender: self)
+            }
+        )
+        DispatchQueue.main.async {
+            self.present(savePassphraseAlert, animated: true)
         }
     }
 

--- a/pass/Controllers/GitRepositorySettingsTableViewController.swift
+++ b/pass/Controllers/GitRepositorySettingsTableViewController.swift
@@ -193,11 +193,23 @@ class GitRepositorySettingsTableViewController: UITableViewController, PasswordA
                     checkoutProgressBlock: checkoutProgressBlock
                 )
 
+                let gpgIdFile = self.passwordStore.storeURL.appendingPathComponent(".gpg-id").path
+                guard FileManager.default.fileExists(atPath: gpgIdFile) else {
+                    self.passwordStore.eraseStoreData()
+                    SVProgressHUD.dismiss {
+                        DispatchQueue.main.async {
+                            Utils.alert(title: "Error".localize(), message: "NoProperPassRepo.".localize(), controller: self)
+                        }
+                    }
+                    return
+                }
+
                 SVProgressHUD.dismiss {
                     self.savePassphraseAndSegue()
                 }
             } catch {
                 SVProgressHUD.dismiss {
+                    self.passwordStore.eraseStoreData()
                     let error = error as NSError
                     var message = error.localizedDescription
                     if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError {

--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "MakeSurePgpAndGitProperlySet."                     = "Stelle bitte sicher, dass die Einstellungen für GPG-Schlüssel und Git-Server richtig sind.";
 "RecoverySuggestion."                               = "Das falsche Passwort wurde entfernt. Bitte probiere es erneut.";
 "NSURLFileAllocatedSizeKeyShouldAlwaysReturnValue." = "Huh? NSURLFileAllocatedSizeKey sollte immer einen Wert liefern.";
+"NoProperPassRepo."                                 = "Das Repository enthält keine .gpg-id Datei. Es muss erst noch mit 'pass init' korrekt initialisiert werden, bevor es in die App geladen werden kann.";
 
 // Settings
 "PasswordGeneratorFlavor"           = "Art";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "MakeSurePgpAndGitProperlySet."                     = "Please make sure PGP key and Git server are properly set.";
 "RecoverySuggestion."                               = "Recovery suggestion: Wrong credential password/passphrase has been removed, please try again.";
 "NSURLFileAllocatedSizeKeyShouldAlwaysReturnValue." = "Huh? NSURLFileAllocatedSizeKey should always return a value.";
+"NoProperPassRepo."                                 = "The repository does not contain a .gpg-id file. Please set it up properly by performing 'pass init'. Then try again to load it into the app.";
 
 // Settings
 "PasswordGeneratorFlavor"           = "Style";

--- a/passKit/Models/PasswordStore.swift
+++ b/passKit/Models/PasswordStore.swift
@@ -618,30 +618,34 @@ public class PasswordStore {
         }
     }
 
-    public func erase() {
+    public func eraseStoreData() {
         // Delete files.
         try? fileManager.removeItem(at: storeURL)
         try? fileManager.removeItem(at: tempStoreURL)
 
-        // Delete PGP key, SSH key and other secrets from the keychain.
-        AppKeychain.shared.removeAllContent()
-
         // Delete core data.
         deleteCoreData(entityName: "PasswordEntity")
-
-        // Delete default settings.
-        Defaults.removeAll()
 
         // Clean up variables inside PasswordStore.
         storeRepository = nil
 
-        // Delete cache explicitly.
-        PasscodeLock.shared.delete()
-        PGPAgent.shared.uninitKeys()
-
         // Broadcast.
         NotificationCenter.default.post(name: .passwordStoreUpdated, object: nil)
         NotificationCenter.default.post(name: .passwordStoreErased, object: nil)
+    }
+
+    public func erase() {
+        eraseStoreData()
+
+        // Delete PGP key, SSH key and other secrets from the keychain.
+        AppKeychain.shared.removeAllContent()
+
+        // Delete default settings.
+        Defaults.removeAll()
+
+        // Delete cache explicitly.
+        PasscodeLock.shared.delete()
+        PGPAgent.shared.uninitKeys()
     }
 
     // return the number of discarded commits


### PR DESCRIPTION
This should fix the crash reported by #478. If there is no `.gpg-id` file in the repository, the app requires more and more RAM (at least in the simulator) for some reason. If it behaves the same on a real device iOS will just kill it at some point.

Pass for iOS can just not work with a repository which was not set up before by `pass init`. This should be a clear requirement.