### PR TITLE
Update YubiKit to version that supports iOS 12

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -2843,7 +2843,7 @@
 			repositoryURL = "https://github.com/Yubico/yubikit-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/pass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/pass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/Yubico/yubikit-ios",
         "state": {
           "branch": null,
-          "revision": "7e75fe8f057acf9bf7ac134d375783a1d409f79e",
-          "version": "4.1.0"
+          "revision": "7b19be11a362d9e52eac0d76b5d904560b9e5ea7",
+          "version": "4.2.0"
         }
       }
     ]

--- a/pass/Controllers/PasswordDetailTableViewController.swift
+++ b/pass/Controllers/PasswordDetailTableViewController.swift
@@ -12,6 +12,7 @@ import passAutoFillExtension
 import passKit
 import SVProgressHUD
 import UIKit
+import YubiKit
 
 class PasswordDetailTableViewController: UITableViewController, UIGestureRecognizerDelegate, AlertPresenting {
     var passwordEntity: PasswordEntity?

--- a/pass/Helpers/Objective-CBridgingHeader.h
+++ b/pass/Helpers/Objective-CBridgingHeader.h
@@ -10,6 +10,5 @@
 #define Objective_CBridgingHeader_h
 
 @import ObjectiveGit;
-#import "YubiKit.h"
 
 #endif /* Objective_CBridgingHeader_h */


### PR DESCRIPTION
This version removes YubiKit's use of CryptoTokenKit, an Apple framework
which has buggy symbol-level availability annotations that confuses the
automatic weak linking system in Xcode.

This is necessary to restore iOS 12 support after #533.

For further history see https://github.com/mssun/passforios/issues/539