### PR TITLE
Exclude the vendor dir for swiftformat and swiftlint

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,7 +5,8 @@
 --exclude       \
     Carthage,   \
     go,         \
-    Pods
+    Pods,       \
+    vendor
 
 ## Enabled rules
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ excluded:
   - Carthage
   - go
   - Pods
+  - vendor
 
 ## Active rules
 


### PR DESCRIPTION
Exclude the vendor dir for swiftformat and swiftlint.