### PR TITLE
fix #540, duplicate entries in auto fill extension

### DIFF
--- a/pass/Controllers/GitRepositorySettingsTableViewController.swift
+++ b/pass/Controllers/GitRepositorySettingsTableViewController.swift
@@ -172,6 +172,7 @@ class GitRepositorySettingsTableViewController: UITableViewController, PasswordA
 
         // Remember git credential password/passphrase temporarily, ask whether users want this after a successful clone.
         Defaults.isRememberGitCredentialPassphraseOn = true
+        // swiftlint:disable:next closure_body_length
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let transferProgressBlock: (UnsafePointer<git_transfer_progress>, UnsafeMutablePointer<ObjCBool>) -> Void = { git_transfer_progress, _ in

--- a/pass/Controllers/QRScannerController.swift
+++ b/pass/Controllers/QRScannerController.swift
@@ -140,11 +140,12 @@ class QRScannerController: UIViewController, AVCaptureMetadataOutputObjectsDeleg
             preferredStyle: .alert
         )
         alertController.addAction(UIAlertAction(title: "Cancel".localize(), style: .default))
-        alertController.addAction(UIAlertAction(title: "Settings".localize(), style: .cancel) { _ in
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.open(url)
+        alertController.addAction(
+            UIAlertAction(title: "Settings".localize(), style: .cancel) { _ in
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
             }
-        }
         )
         present(alertController, animated: true)
     }

--- a/pass/Services/PasswordDecryptor.swift
+++ b/pass/Services/PasswordDecryptor.swift
@@ -192,7 +192,7 @@ public func yubiKeyDecrypt(
 extension Data {
     struct HexEncodingOptions: OptionSet {
         let rawValue: Int
-        static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
+        static let upperCase = Self(rawValue: 1 << 0)
     }
 
     func hexEncodedString(options: HexEncodingOptions = []) -> String {

--- a/passAutoFillExtension/Services/PasswordsTableDataSource.swift
+++ b/passAutoFillExtension/Services/PasswordsTableDataSource.swift
@@ -72,7 +72,7 @@ class PasswordsTableDataSource: NSObject, UITableViewDataSource {
             return
         }
 
-        guard suggestedPasswordsTableEntries.isEmpty && otherPasswordsTableEntries.isEmpty else {
+        guard suggestedPasswordsTableEntries.isEmpty, otherPasswordsTableEntries.isEmpty else {
             return
         }
 

--- a/passAutoFillExtension/Services/PasswordsTableDataSource.swift
+++ b/passAutoFillExtension/Services/PasswordsTableDataSource.swift
@@ -72,6 +72,10 @@ class PasswordsTableDataSource: NSObject, UITableViewDataSource {
             return
         }
 
+        guard suggestedPasswordsTableEntries.isEmpty && otherPasswordsTableEntries.isEmpty else {
+            return
+        }
+
         for entry in passwordTableEntries {
             if entry.matches(text) {
                 suggestedPasswordsTableEntries.append(entry)


### PR DESCRIPTION
`prepareCredentialList` is called twice, once before unlock and once after. If the lists are already prepared, i.e. not empty, skip this step.