### PR TITLE
Fix autofill passwords without passcode/faceid auth

### DIFF
--- a/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
+++ b/passAutoFillExtension/Controllers/PasscodeExtensionDisplay.swift
@@ -22,9 +22,7 @@ class PasscodeExtensionDisplay {
             before?()
             passcodeLockVC.successCallback = after
             passcodeLockVC.modalPresentationStyle = .fullScreen
-            sender.parent?.present(passcodeLockVC, animated: false) {
-                after?()
-            }
+            sender.parent?.present(passcodeLockVC, animated: false)
         } else {
             after?()
         }


### PR DESCRIPTION
# Passcode / FaceID bypass in autofill extension

Fixes: #537
Fixes: #568

| Before Fix | After Fix |
| --- | --- |
| https://user-images.githubusercontent.com/6374032/221751617-fb5a3715-7aec-4a81-8df4-ba39a5d890e3.mp4 | https://user-images.githubusercontent.com/6374032/221751647-40aa5260-7035-4276-be48-a559c47a9dea.mp4 |

## Summary
When enrolled in passcode protection, the autofill extension currently calls the success callback even if a passcode/FaceID is not successfully verified.

In the case that the PGP key passphrase is stored, this additionally results in password decryption without further user interaction.

For the case that passcode protection is enabled, the fix is to only decrypt passwords upon successful passcode / FaceID verification.