### PR TITLE
Fix missing Italian translation

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		DC13B14E1E8640810097803F /* passTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = passTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC13B1521E8640810097803F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC193FF91E49B4430077E0A3 /* AdvancedSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AdvancedSettingsTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		DC30F83629BAFD2E001EB12B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		DC3E64E51E656F11009A83DE /* CommitLogsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommitLogsTableViewController.swift; sourceTree = "<group>"; };
 		DC4914941E434301007FF592 /* LabelTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelTableViewCell.swift; sourceTree = "<group>"; };
 		DC4914981E434600007FF592 /* PasswordDetailTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordDetailTableViewController.swift; sourceTree = "<group>"; };
@@ -1338,6 +1339,7 @@
 				en,
 				Base,
 				de,
+				it,
 			);
 			mainGroup = DC917BCA1E2E8231000FDF54;
 			packageReferences = (
@@ -1812,6 +1814,7 @@
 				DC917BDB1E2E8231000FDF54 /* Base */,
 				30C25DA921F34D2800BB27BB /* en */,
 				30C25DC321F3BEF500BB27BB /* de */,
+				DC30F83629BAFD2E001EB12B /* it */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";


### PR DESCRIPTION
I have added Italian in the Localizations in the project info. Refer: https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions

Don't know why this entry is missing.

Fix #606.