### PR TITLE
Switch prevalence of user and login field

### DIFF
--- a/passKit/Models/Password.swift
+++ b/passKit/Models/Password.swift
@@ -125,8 +125,8 @@ public class Password {
         additions.filter { field in
             let title = field.title.lowercased()
             return title != Constants.USERNAME_KEYWORD
-                && title != Constants.USER_KEYWORD
                 && title != Constants.LOGIN_KEYWORD
+                && title != Constants.USER_KEYWORD
                 && title != Constants.PASSWORD_KEYWORD
                 && (!Constants.isUnknown(title) || !Defaults.isHideUnknownOn)
                 && (!Constants.isOtpKeyword(title) || !Defaults.isHideOTPOn)
@@ -220,6 +220,6 @@ public class Password {
     }
 
     public func getUsernameForCompletion() -> String {
-        username ?? user ?? login ?? nameFromPath ?? ""
+        username ?? login ?? user ?? nameFromPath ?? ""
     }
 }


### PR DESCRIPTION
Concerning https://github.com/mssun/passforios/issues/611 and https://github.com/mssun/passforios/issues/488.

This should switch the prevalence of the `user` and `login` field for autofill. If anything it's a quick hack. The real fix would be to set up a setting which field to use for autofill. 

I don't have a Swift pipeline set up so I can't really test it.