### PR TITLE
Update gopenpgp to v2.8.1 with passforios patches

### DIFF
--- a/scripts/gopenpgp_build.sh
+++ b/scripts/gopenpgp_build.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-GOPENPGP_VERSION="v2.6.0-passforios"
+GOPENPGP_VERSION="v2.8.1-passforios"
 
 export GOPATH="$(pwd)/go"
 export PATH="$PATH:$GOPATH/bin"


### PR DESCRIPTION
Upgrade the following dependencies with passforios patches:

- gopenpgp v2.8.1: https://github.com/mssun/gopenpgp/tree/v2.8.1-passforios
- go-crypto: v1.1.3: https://github.com/mssun/go-crypto/tree/v1.1.3-passforios