### PR TITLE
(Fix) autofill / extensions and restore persistent storage location

### DIFF
--- a/pass/AppDelegate.swift
+++ b/pass/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var passcodeLockPresenter = PasscodeLockPresenter(mainWindow: self.window)
 
     func application(_: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        PersistenceController.shared.setup()
         // Override point for customization after application launch.
         SVProgressHUD.setMinimumSize(CGSize(width: 150, height: 100))
         passcodeLockPresenter.present(windowLevel: UIApplication.shared.windows.last?.windowLevel.rawValue)

--- a/passKit/Controllers/CoreDataStack.swift
+++ b/passKit/Controllers/CoreDataStack.swift
@@ -28,9 +28,10 @@ public class PersistenceController {
         } else {
             description?.url = URL(fileURLWithPath: Globals.dbPath)
         }
+        setup()
     }
 
-    public func setup() {
+    func setup() {
         container.loadPersistentStores { _, error in
             if error != nil {
                 self.reinitializePersistentStore()

--- a/passKit/Controllers/CoreDataStack.swift
+++ b/passKit/Controllers/CoreDataStack.swift
@@ -25,6 +25,8 @@ public class PersistenceController {
         description?.shouldInferMappingModelAutomatically = false
         if isUnitTest {
             description?.url = URL(fileURLWithPath: "/dev/null")
+        } else {
+            description?.url = URL(fileURLWithPath: Globals.dbPath)
         }
     }
 

--- a/passKitTests/CoreData/CoreDataTestCase.swift
+++ b/passKitTests/CoreData/CoreDataTestCase.swift
@@ -21,7 +21,6 @@ class CoreDataTestCase: XCTestCase {
         try super.setUpWithError()
 
         controller = PersistenceController(isUnitTest: true)
-        controller.setup()
     }
 
     override func tearDown() {


### PR DESCRIPTION
Fixes: #685 
Fixes: #684 
Fixes: #683

There are 2 changes here to restore autofill / extension functionality

##     Add persistent DB path for extension access
    
Using the existing sqlite DB path maintains backwards compatibility with
the existing persistent store.

Assuming the DB path should be maintained from v0.16

This should fix issues reported where there are no entries for the
repository.

##     Move persistence controller setup into the init
    
App extensions access the persistent storage. From the refactor, the
persistent storage "setup" is no longer called which breaks the
extension and the pass auto fill.

This commit moves the persistent storage setup into the init for the
shared storage, which should be called once for the first read access or
in preparation for a write.

As a result, extensions should now work as expected.

https://github.com/user-attachments/assets/71354398-7f8f-4126-9cd7-996d10f7c021