### PR TITLE
Upgrade gopenpgp dependency to v2.10.0

### DIFF
--- a/scripts/gopenpgp_build.sh
+++ b/scripts/gopenpgp_build.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-GOPENPGP_VERSION="v2.8.1-passforios"
+GOPENPGP_VERSION="v2.10.0-passforios"
 
 export GOPATH="$(pwd)/go"
 export PATH="$PATH:$GOPATH/bin"


### PR DESCRIPTION
## Summary
- Bump the pinned gopenpgp fork from `v2.8.1-passforios` to `v2.10.0-passforios` in `scripts/gopenpgp_build.sh`.
- Rebased the passforios-specific patches onto current upstream releases:
  - [mssun/gopenpgp](https://github.com/mssun/gopenpgp) `v2.10.0-passforios`: the `helper.go` additions (`PassGetEncryptedMPI1/2`, `PassDecryptWithSessionKey`) used for password-protected message decryption, rebased onto upstream gopenpgp v2.10.0.
  - [mssun/go-crypto](https://github.com/mssun/go-crypto) `v1.4.1-mssun-passforios`: the `EncryptedKey` MPI getter methods, rebased onto upstream go-crypto v1.4.1 (the version gopenpgp v2.10.0 requires).

## Test plan
- [x] `go build` / `go vet` / `go test ./crypto/... ./helper/...` pass for both rebased forks against the real published tags.
- [x] Ran `scripts/gopenpgp_build.sh` end-to-end; `gomobile bind` produced a working `Gopenpgp.xcframework` (device + simulator slices).
- [x] Built the `pass` scheme against the new xcframework — succeeds.
- [x] Ran `passKitTests/CryptoFrameworkTest` and `passKitTests/PGPAgentTest` (10 tests: encrypt/decrypt, corrupted/incompatible keys, multi-key, wrong passphrase) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)