### PR TITLE
Fix user field not displayed in password detail view

### DIFF
--- a/pass/Controllers/PasswordDetailTableViewController.swift
+++ b/pass/Controllers/PasswordDetailTableViewController.swift
@@ -262,7 +262,7 @@ class PasswordDetailTableViewController: UITableViewController, UIGestureRecogni
         if let username = password.username {
             section.item.append(Constants.USERNAME_KEYWORD => username)
         }
-        if let user = password.username {
+        if let user = password.user {
             section.item.append(Constants.USER_KEYWORD => user)
         }
         if let login = password.login {


### PR DESCRIPTION
## Summary
- `setTableData()` had a copy-paste bug: the block meant to show the `User` row checked `password.username` instead of `password.user`, so the `user` field was silently dropped whenever `username` was absent (it would only ever show up duplicated under the "Username" label).
- Fixes the confusion reported in #611 where the `user` field is used for autofill but never shown in the detail view.

## Test plan
- [x] `xcodebuild test -project pass.xcodeproj -scheme pass -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5'` — build succeeded, 120 tests passed (1 skipped) across `passKitTests` and `passTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)