### PR TITLE
Fix test suite build error and flaky/broken tests

### DIFF
--- a/passKit/Controllers/PersistenceController.swift
+++ b/passKit/Controllers/PersistenceController.swift
@@ -17,9 +17,11 @@ public class PersistenceController {
     }
 
     let container: NSPersistentContainer
+    let repositoryURL: URL
 
-    init(storeURL: URL = Globals.dbURL) {
+    init(storeURL: URL = Globals.dbURL, repositoryURL: URL = Globals.repositoryURL) {
         self.container = NSPersistentContainer(name: Self.modelName, managedObjectModel: .sharedModel)
+        self.repositoryURL = repositoryURL
         let description = container.persistentStoreDescriptions.first
         description?.shouldMigrateStoreAutomatically = false
         description?.shouldInferMappingModelAutomatically = false
@@ -42,7 +44,7 @@ public class PersistenceController {
                 fatalError("Failed to load persistent stores: \(finalError.localizedDescription)")
             }
         }
-        PasswordEntity.initPasswordEntityCoreData(url: Globals.repositoryURL, in: container.viewContext)
+        PasswordEntity.initPasswordEntityCoreData(url: repositoryURL, in: container.viewContext)
         try? container.viewContext.save()
     }
 

--- a/passKitTests/Controllers/PersistenceControllerTest.swift
+++ b/passKitTests/Controllers/PersistenceControllerTest.swift
@@ -43,8 +43,9 @@ final class PersistenceControllerTest: XCTestCase {
         controller.reinitializePersistentStore()
 
         // After reinitialize, old data should be gone
-        // (reinitializePersistentStore calls initPasswordEntityCoreData with the default repo URL,
-        // which won't exist in tests, so the result should be an empty store)
+        // (reinitializePersistentStore rescans PersistenceController's repositoryURL, which
+        // forUnitTests() points at a fresh, isolated temp directory, so the result should be
+        // an empty store regardless of what's on the real device)
         let remaining = PasswordEntity.fetchAll(in: context)
         XCTAssertEqual(remaining.count, 0)
     }

--- a/passKitTests/Fixtures/password-store-empty-dirs.git/refs/heads/main
+++ b/passKitTests/Fixtures/password-store-empty-dirs.git/refs/heads/main
@@ -1,0 +1,1 @@
+fbcbb5819e1c864ef33cfffa179a71387a5d90d0

--- a/passKitTests/Fixtures/password-store-empty.git/refs/heads/main
+++ b/passKitTests/Fixtures/password-store-empty.git/refs/heads/main
@@ -1,0 +1,1 @@
+f095bb4897e4cd58faadfe4d4f678fb697be3ffd

--- a/passKitTests/Models/PasswordStoreTest.swift
+++ b/passKitTests/Models/PasswordStoreTest.swift
@@ -88,7 +88,7 @@ final class PasswordStoreTest: XCTestCase {
         XCTAssertFalse(AppKeychain.shared.contains(key: PGPKey.PUBLIC.getKeychainKey()))
         XCTAssertFalse(Defaults.hasKey(\.gitSignatureName))
         XCTAssertFalse(PasscodeLock.shared.hasPasscode)
-        XCTAssertFalse(PGPAgent.shared.isInitialized())
+        XCTAssertFalse(PGPAgent.shared.isInitialized)
         waitForExpectations(timeout: 1, handler: nil)
     }
 

--- a/passKitTests/TestHelpers/PersistenceController+UnitTestHelpers.swift
+++ b/passKitTests/TestHelpers/PersistenceController+UnitTestHelpers.swift
@@ -10,6 +10,9 @@
 
 extension PersistenceController {
     static func forUnitTests() -> PersistenceController {
-        PersistenceController(storeURL: URL(fileURLWithPath: "/dev/null"))
+        PersistenceController(
+            storeURL: URL(fileURLWithPath: "/dev/null"),
+            repositoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- `PGPAgent.shared.isInitialized` is a property, not a method — fixes a compile error blocking the whole test suite.
- Restore the missing `refs/heads/main` loose ref in the `password-store-empty(-dirs)` fixtures. Git can't commit empty directories, and these bare-repo fixtures had no loose refs (only `packed-refs`), so their `refs/` directory never made it into the repo — making `git clone` fail with "repository does not exist".
- Make `PersistenceController.repositoryURL` injectable (mirroring the existing `storeURL` parameter) so `forUnitTests()` can point it at an isolated temp directory instead of rescanning the real device-shared password store, which made `testReinitializePersistentStoreClearsData` flaky depending on what was already on the simulator.

## Test plan
- [x] `bundle exec fastlane test` — 153 tests, 0 failures, 1 skipped