### PR TITLE
clarify PGP subkey export instructions (fix #693)

### DIFF
--- a/pass/de.lproj/Localizable.strings
+++ b/pass/de.lproj/Localizable.strings
@@ -308,45 +308,45 @@ gibt den Schlüssel in diesem speziellen Format aus. Kopiere ihn so zu einem Spe
 
 "GpgAsciiArmorCopyExplanation." = "GnuPG unterstützt die Kommandozeilenoption \"-a\", welche die Schlüssel im Format \"ASCII-Armor\" ausgibt. Es ist anders als das Binärformat eine einfache Zeichenkette. Der Befehl
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um die KEY_ID des untergeorneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
+zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um den Fingerabdruck des untergeordneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Mit
+können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Verwende dabei den Fingerabdruck des Unterschlüssels (E) und nicht den des Hauptschlüssels: Das angehängte \"!\" beschränkt den Export auf genau diesen Schlüssel. Mit dem Fingerabdruck des Hauptschlüssels wird deshalb überhaupt kein Unterschlüssel zur Verschlüsselung exportiert und die App lehnt das Ergebnis als abgelaufen oder inkompatibel ab. Mit
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 wird überprüft, dass nicht aus Versehen der Unterschlüssel für Authentifizierungen exportiert wurde. Die Zwischenablage wird nach 45 Sekunden zurückgesetzt.";
 
 "GpgAsciiArmorServerExplanation." = "GnuPG unterstützt die Kommandozeilenoption \"-a\", welche die Schlüssel im Format \"ASCII-Armor\" ausgibt. Es ist anders als das Binärformat eine einfache Zeichenkette. Der Befehl
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um die KEY_ID des untergeorneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
+zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um den Fingerabdruck des untergeordneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Mit
+können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Verwende dabei den Fingerabdruck des Unterschlüssels (E) und nicht den des Hauptschlüssels: Das angehängte \"!\" beschränkt den Export auf genau diesen Schlüssel. Mit dem Fingerabdruck des Hauptschlüssels wird deshalb überhaupt kein Unterschlüssel zur Verschlüsselung exportiert und die App lehnt das Ergebnis als abgelaufen oder inkompatibel ab. Mit
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 wird überprüft, dass nicht aus Versehen der Unterschlüssel für Authentifizierungen exportiert wurde. Schließlich können die beiden Schlüssel auf einen (lokalen) HTTP(S)-Server kopiert werden.";
 
 "GpgAsciiArmorFileExplanation." = "GnuPG unterstützt die Kommandozeilenoption \"-a\", welche die Schlüssel im Format \"ASCII-Armor\" ausgibt. Es ist anders als das Binärformat eine einfache Zeichenkette. Der Befehl
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um die KEY_ID des untergeorneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
+zeigt alle bekannten Schlüssel an. Die Liste kann verwendet werden, um den Fingerabdruck des untergeordneten Schlüssels (E) zu identifizieren. Er wird zur Verschlüsselung verwendet. Mit den Befehlen
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Mit
+können der öffentliche und der private Unterschlüssel im \"ASCII-Armor\"- Format exportiert werden. Verwende dabei den Fingerabdruck des Unterschlüssels (E) und nicht den des Hauptschlüssels: Das angehängte \"!\" beschränkt den Export auf genau diesen Schlüssel. Mit dem Fingerabdruck des Hauptschlüssels wird deshalb überhaupt kein Unterschlüssel zur Verschlüsselung exportiert und die App lehnt das Ergebnis als abgelaufen oder inkompatibel ab. Mit
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 wird überprüft, dass nicht aus Versehen der Unterschlüssel für Authentifizierungen exportiert wurde. Schließlich können die beiden Schlüssel an einem Ort gespeichert werden, der für die Dateien-App zugänglich ist.";

--- a/pass/en.lproj/Localizable.strings
+++ b/pass/en.lproj/Localizable.strings
@@ -309,45 +309,45 @@ to get the key in this specific format. Subsequently, copy it to a location acce
 
 "GpgAsciiArmorCopyExplanation." = "GnuPG supports the command-line option \"-a\" that causes output to be generated in an ASCII-armored format similar to unencoded documents rather than the binary format. Use
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-to identify your encryption (E) subkey's KEY_ID, then use
+to identify the fingerprint of your encryption (E) subkey, then use
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-to get the public and the encryption private subkeys in this specific format. Check that no authentication subkey is accidentally exported:
+to get the public and the encryption private subkeys in this specific format. Use the fingerprint of the (E) subkey, not the one of your primary key: the trailing \"!\" restricts the export to exactly that key, so pairing it with the primary key's fingerprint exports no encryption subkey at all and the app rejects the result as expired or incompatible. Check that no authentication subkey is accidentally exported:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 The clipboard will be cleared 45s after pasting.";
 
 "GpgAsciiArmorServerExplanation." = "GnuPG supports the command-line option \"-a\" that causes output to be generated in an ASCII-armored format similar to unencoded documents rather than the binary format. Use
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-to identify your encryption (E) subkey's KEY_ID, then use
+to identify the fingerprint of your encryption (E) subkey, then use
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-to get the public and the encryption private subkeys in this specific format. Check that no authentication subkey is accidentally exported:
+to get the public and the encryption private subkeys in this specific format. Use the fingerprint of the (E) subkey, not the one of your primary key: the trailing \"!\" restricts the export to exactly that key, so pairing it with the primary key's fingerprint exports no encryption subkey at all and the app rejects the result as expired or incompatible. Check that no authentication subkey is accidentally exported:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 Finally, copy them to your (local) HTTP(S) server.";
 
 "GpgAsciiArmorFileExplanation." = "GnuPG supports the command-line option \"-a\" that causes output to be generated in an ASCII-armored format similar to unencoded documents rather than the binary format. Use
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-to identify your encryption (E) subkey's KEY_ID, then use
+to identify the fingerprint of your encryption (E) subkey, then use
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-to get the public and the encryption private subkeys in this specific format. Check that no authentication subkey is accidentally exported:
+to get the public and the encryption private subkeys in this specific format. Use the fingerprint of the (E) subkey, not the one of your primary key: the trailing \"!\" restricts the export to exactly that key, so pairing it with the primary key's fingerprint exports no encryption subkey at all and the app rejects the result as expired or incompatible. Check that no authentication subkey is accidentally exported:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 Finally, copy them to a location accessible by the Files app.";

--- a/pass/it.lproj/Localizable.strings
+++ b/pass/it.lproj/Localizable.strings
@@ -304,45 +304,45 @@ per ottenere la chiave in questo formato. Dopodiché, copiarla in una posizione 
 
 "GpgAsciiArmorCopyExplanation." = "GnuPG supporta l'opzione da riga di comando \"-a\" per generare le chiavi in un formato con armatura ASCII, simile a documenti non codificati e non al formato binario. Usare
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-per identificare il KEY_ID della sottochiave di criptazione (E), poi usare
+per identificare l'impronta della sottochiave di criptazione (E), poi usare
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
+per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Usare l'impronta della sottochiave (E) e non quella della chiave primaria: il \"!\" finale limita l'esportazione esattamente a quella chiave, quindi con l'impronta della chiave primaria non viene esportata alcuna sottochiave di criptazione e l'app rifiuta il risultato come scaduto o non corrispondente. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 Gli appunti saranno cancellati 45s dopo aver incollato.";
 
 "GpgAsciiArmorServerExplanation." = "GnuPG supporta l'opzione da riga di comando \"-a\" per generare le chiavi in un formato con armatura ASCII, simile a documenti non codificati e non al formato binario. Usare
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-per identificare il KEY_ID della sottochiave di criptazione (E), poi usare
+per identificare l'impronta della sottochiave di criptazione (E), poi usare
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
+per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Usare l'impronta della sottochiave (E) e non quella della chiave primaria: il \"!\" finale limita l'esportazione esattamente a quella chiave, quindi con l'impronta della chiave primaria non viene esportata alcuna sottochiave di criptazione e l'app rifiuta il risultato come scaduto o non corrispondente. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 Infine, copiarle nel server HTTP(S) (che può essere locale).";
 
 "GpgAsciiArmorFileExplanation." = "GnuPG supporta l'opzione da riga di comando \"-a\" per generare le chiavi in un formato con armatura ASCII, simile a documenti non codificati e non al formato binario. Usare
 
-  $ gpg --list-keys
+  $ gpg --list-keys --with-subkey-fingerprints
 
-per identificare il KEY_ID della sottochiave di criptazione (E), poi usare
+per identificare l'impronta della sottochiave di criptazione (E), poi usare
 
-  $ gpg --export -a KEY_ID! > subkey.pub
-  $ gpg --export-secret-subkeys -a KEY_ID! > subkey
+  $ gpg --export -a SUBKEY_FINGERPRINT! > subkey.pub
+  $ gpg --export-secret-subkeys -a SUBKEY_FINGERPRINT! > subkey
 
-per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
+per ottenere la sottochiave pubblica e quella privata di criptazione in questo formato. Usare l'impronta della sottochiave (E) e non quella della chiave primaria: il \"!\" finale limita l'esportazione esattamente a quella chiave, quindi con l'impronta della chiave primaria non viene esportata alcuna sottochiave di criptazione e l'app rifiuta il risultato come scaduto o non corrispondente. Verificare che nessuna sottochiave di autenticazione sia stata esportata per errore:
 
-  $ gpg --show-key subkey
+  $ gpg --show-keys subkey
 
 Infine, copiarla in una posizione a cui File abbia accesso.";


### PR DESCRIPTION
Fixes #693.

## The problem

The in-app key import instructions said:

```
$ gpg --list-keys

to identify your encryption (E) subkey's KEY_ID, then use

$ gpg --export -a KEY_ID! > subkey.pub
$ gpg --export-secret-subkeys -a KEY_ID! > subkey
```

The trailing `!` means "export exactly this one key, nothing else." But the placeholder is named `KEY_ID` and the suggested `gpg --list-keys` shows the primary key most prominently, so users naturally attach `!` to the **primary** key's ID. I reproduced both branches against real gpg keys (a key with `[E]`, `[S]` and `[A]` subkeys):

| ID used with `!` | public export | secret export |
|---|---|---|
| **(E) subkey** fingerprint | primary + E subkey ✅ | primary stub + real `skey[]` material ✅ |
| **primary** fingerprint | primary only, **no subkey** ❌ | `gnu-dummy` stub, **zero secret material** ❌ |

`--export-secret-subkeys PRIMARY!` is self-contradictory: it asks for secret *subkeys* while restricting output to the primary key, so it yields a stub containing nothing.

That pair has no encryption-capable subkey, so decryption fails in [`GopenPGPInterface`](passKit/Crypto/GopenPGPInterface.swift#L14) with `openpgp: incorrect key`, which maps to `AppError.keyExpiredOrIncompatible` and reaches the user as "PGP public key may be expired or incompatible with the private key" — exactly what the reporter saw.

## Why not just delete the `!`

That is what the reporter did, and it works — but for an incidental reason. Without `!`, gpg widens selection from "this key" to "the whole keyblock containing this key," so the E subkey is always included. I confirmed this holds *regardless of which ID is passed*: exporting with the subkey ID and no `!` still emitted all three subkeys.

The cost is that it also ships the **signing and authentication** subkeys' secret material to the phone — precisely what the next line of the instructions ("check that no authentication subkey is accidentally exported") exists to prevent. So `!` is worth keeping; the ambiguity is the actual bug.

## The change

Keep `!`, remove the ambiguity:

- rename the placeholder `KEY_ID` → `SUBKEY_FINGERPRINT`
- `gpg --list-keys` → `gpg --list-keys --with-subkey-fingerprints` (older gpg does not show subkey fingerprints by default, making the instruction impossible to follow)
- add an explicit warning against using the primary key's fingerprint, naming the error it produces
- `--show-key` → `--show-keys` (the singular form only worked as an unambiguous-abbreviation fallback)

Applied to all three explanation blocks — `GpgAsciiArmorCopyExplanation.`, `...ServerExplanation.`, `...FileExplanation.` — in `en`, `de` and `it` (6 command occurrences per locale).

## Notes for the reviewer

- Strings-only change; no Swift touched.
- All three files verified with `plutil -lint`; no `KEY_ID` or singular `--show-key` remains in any locale.
- **The `de` and `it` translations of the new warning sentence were written by me and would benefit from a native-speaker review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)