### PR TITLE
ignore non-.gpg files when scanning the store

### DIFF
--- a/passKit/Models/PasswordEntity.swift
+++ b/passKit/Models/PasswordEntity.swift
@@ -179,17 +179,17 @@ public final class PasswordEntity: NSManagedObject, Identifiable {
                 else {
                     continue
                 }
+                // Ignore files that are not passwords, e.g., a README.md documenting the store.
+                guard isDirectory || (name as NSString).pathExtension.lowercased() == "gpg" else {
+                    continue
+                }
                 let passwordEntity = PasswordEntity(context: context)
                 passwordEntity.isDir = isDirectory
                 if isDirectory {
                     passwordEntity.name = name
                     queue.append(passwordEntity)
                 } else {
-                    if (name as NSString).pathExtension == "gpg" {
-                        passwordEntity.name = (name as NSString).deletingPathExtension
-                    } else {
-                        passwordEntity.name = name
-                    }
+                    passwordEntity.name = (name as NSString).deletingPathExtension
                 }
                 passwordEntity.parent = current
                 passwordEntity.path = String(fileURL.path.dropFirst(url.path.count + 1))

--- a/passKitTests/CoreData/PasswordEntityTest.swift
+++ b/passKitTests/CoreData/PasswordEntityTest.swift
@@ -100,7 +100,7 @@ final class PasswordEntityTest: CoreDataTestCase {
         //   social/
         //     mastodon.gpg
         //   toplevel.gpg
-        //   notes.txt          (non-.gpg file)
+        //   notes.txt          (non-.gpg file, ignored)
         let emailDir = rootDir.appendingPathComponent("email")
         let socialDir = rootDir.appendingPathComponent("social")
         try FileManager.default.createDirectory(at: emailDir, withIntermediateDirectories: true)
@@ -118,7 +118,7 @@ final class PasswordEntityTest: CoreDataTestCase {
         let allEntities = PasswordEntity.fetchAll(in: context)
         let files = allEntities.filter { !$0.isDir }
         let dirs = allEntities.filter(\.isDir)
-        XCTAssertEqual(files.count, 5) // 4 .gpg + 1 .txt
+        XCTAssertEqual(files.count, 4) // 4 .gpg, notes.txt is ignored
         XCTAssertEqual(dirs.count, 2) // email, social
 
         // Verify .gpg extension is stripped
@@ -126,10 +126,8 @@ final class PasswordEntityTest: CoreDataTestCase {
         XCTAssertNotNil(workEntity)
         XCTAssertEqual(workEntity!.name, "work")
 
-        // Verify non-.gpg file keeps its extension
-        let notesEntity = allEntities.first { $0.path == "notes.txt" }
-        XCTAssertNotNil(notesEntity)
-        XCTAssertEqual(notesEntity!.name, "notes.txt")
+        // Verify non-.gpg file is not imported
+        XCTAssertNil(allEntities.first { $0.path == "notes.txt" })
 
         // Verify parent-child relationships
         let emailEntity = allEntities.first { $0.path == "email" && $0.isDir }
@@ -160,6 +158,24 @@ final class PasswordEntityTest: CoreDataTestCase {
         let allEntities = PasswordEntity.fetchAll(in: context)
         XCTAssertEqual(allEntities.count, 1)
         XCTAssertEqual(allEntities.first!.name, "visible")
+    }
+
+    func testInitPasswordEntityCoreDataIgnoresNonPasswordFiles() throws {
+        let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+
+        try Data("test".utf8).write(to: rootDir.appendingPathComponent("email.gpg"))
+        try Data("# Password Store".utf8).write(to: rootDir.appendingPathComponent("README.md"))
+        try Data("*.gpg diff=gpg".utf8).write(to: rootDir.appendingPathComponent("gitattributes"))
+        try Data("test".utf8).write(to: rootDir.appendingPathComponent("no-extension"))
+
+        let context = controller.viewContext()
+        PasswordEntity.initPasswordEntityCoreData(url: rootDir, in: context)
+
+        let allEntities = PasswordEntity.fetchAll(in: context)
+        XCTAssertEqual(allEntities.count, 1)
+        XCTAssertEqual(allEntities.first!.name, "email")
     }
 
     func testInitPasswordEntityCoreDataHandlesEmptyDirectory() throws {


### PR DESCRIPTION
Fixes #714.

## Problem

`PasswordEntity.initPasswordEntityCoreData` imported every non-hidden file it found while walking the store, regardless of extension. A `README.md` in the repository root — useful documentation when browsing the store on GitHub — showed up as a password entry named `README.md`.

## Change

Skip files whose extension isn't `gpg` while building the Core Data tree. The name-assignment branch collapses to an unconditional `deletingPathExtension`, since only `.gpg` files reach it now.

The `.gpg` extension is fixed in the pass specification and not configurable: upstream builds every path as `"$PREFIX/$path.gpg"` and discovers entries with `find -iname '*.gpg'`. The comparison here is case-insensitive to match that `-iname`. This app already only ever writes `.gpg` (`url.appendingPathExtension("gpg")` in `PasswordEditorTableViewController.getNamePath`), so nothing it creates is affected.

Behavior change worth noting: a hand-made store containing an encrypted file *without* a `.gpg` extension would previously list it and decrypt it on tap (decryption is extension-blind — it just reads the bytes at the entity path). Such a file is now skipped, which is also what upstream `pass ls` does with it.

A directory left with no importable children (e.g. `docs/` holding only markdown) now shows as an empty folder rather than a folder of bogus entries. Pruning childless directories is deliberately out of scope here.

## Tests

- Updated `testInitPasswordEntityCoreDataBuildsTree`: the existing `notes.txt` fixture is now asserted absent.
- Added `testInitPasswordEntityCoreDataIgnoresNonPasswordFiles`: covers `README.md`, a non-hidden `gitattributes`, and an extension-less file alongside a real `.gpg` entry.

Full suite: 144 tests, 0 failures (1 pre-existing skip, `testSSHKeyCredentialProvider`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)