### PR TITLE
show symbolic links under their own name (fix #699)

### DIFF
--- a/pass.xcodeproj/project.pbxproj
+++ b/pass.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		DC64745F2D45B240004B4BBC /* GitRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC64745E2D45B23A004B4BBC /* GitRepository.swift */; };
 		DC6474612D46A8F8004B4BBC /* GitRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6474602D46A8F2004B4BBC /* GitRepositoryTest.swift */; };
 		DC7CBBBD2D0FA3F2003BB4D2 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = DC7CBBBC2D0FA3F2003BB4D2 /* YubiKit */; };
+		DC7CBBC22D0FA3F2003BB4D3 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = DC7CBBC12D0FA3F2003BB4D3 /* DequeModule */; };
 		DC7CBBBF2D0FAC92003BB4D2 /* YKFSmartCardInterfaceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CBBBE2D0FAC8E003BB4D2 /* YKFSmartCardInterfaceExtension.swift */; };
 		DC8963C01E38EEB900828B09 /* SSHKeyURLImportTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8963BF1E38EEB900828B09 /* SSHKeyURLImportTableViewController.swift */; };
 		DC917BD71E2E8231000FDF54 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC917BD61E2E8231000FDF54 /* AppDelegate.swift */; };
@@ -560,6 +561,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC7CBBC22D0FA3F2003BB4D3 /* DequeModule in Frameworks */,
 				DC7CBBBD2D0FA3F2003BB4D2 /* YubiKit in Frameworks */,
 				9ADAB21D26DDA52400900F10 /* Gopenpgp.xcframework in Frameworks */,
 				30A3001426DA6692002A734E /* KeychainAccess in Frameworks */,
@@ -1202,6 +1204,7 @@
 				9A1D1CE426E5D1CE0052028E /* OneTimePassword */,
 				30333B2C2CF9252E008A2EA2 /* SVProgressHUD */,
 				DC7CBBBC2D0FA3F2003BB4D2 /* YubiKit */,
+				DC7CBBC12D0FA3F2003BB4D3 /* DequeModule */,
 			);
 			productName = passKit;
 			productReference = A26075781EEC6F34005DB03E /* passKit.framework */;
@@ -1411,6 +1414,7 @@
 				307CB7522CF9219100D0931F /* XCRemoteSwiftPackageReference "SVProgressHUD" */,
 				30333B292CF922D9008A2EA2 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				DC7CBBBB2D0FA3F2003BB4D2 /* XCRemoteSwiftPackageReference "yubikit-ios" */,
+				DC7CBBC02D0FA3F2003BB4D3 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = DC917BD41E2E8231000FDF54 /* Products */;
 			projectDirPath = "";
@@ -2983,6 +2987,14 @@
 				minimumVersion = 4.7.0;
 			};
 		};
+		DC7CBBC02D0FA3F2003BB4D3 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3090,6 +3102,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DC7CBBBB2D0FA3F2003BB4D2 /* XCRemoteSwiftPackageReference "yubikit-ios" */;
 			productName = YubiKit;
+		};
+		DC7CBBC12D0FA3F2003BB4D3 /* DequeModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DC7CBBC02D0FA3F2003BB4D3 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = DequeModule;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/pass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/pass.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "728388097d1b3fa9558ae377b694945a2a9f0b6c670226aaf4de00602155a938",
+  "originHash" : "d137dafa8e30f6e42ad2317049c4804cd349ed7d6d905fefc1d6c5008a6a5b4b",
   "pins" : [
     {
       "identity" : "base32",
@@ -61,6 +61,15 @@
       "state" : {
         "revision" : "c33f7c775ba7feea6047a1fc3257f2e5863b44f7",
         "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {

--- a/passKit/Models/PasswordEntity.swift
+++ b/passKit/Models/PasswordEntity.swift
@@ -7,6 +7,7 @@
 //
 
 import CoreData
+import DequeModule
 import Foundation
 import ObjectiveGit
 import SwiftyUserDefaults
@@ -162,23 +163,26 @@ public final class PasswordEntity: NSManagedObject, Identifiable {
             entity.path = ""
             return entity
         }()
-        var queue = [root]
-        while !queue.isEmpty {
-            let current = queue.removeFirst()
+        // Directories are enumerated through their resolved URL, so that symbolically linked
+        // directories are traversed as well. A link pointing back up the tree would make the
+        // traversal loop forever, hence every directory also carries the resolved paths of
+        // itself and all its ancestors.
+        var queue: Deque = [(entity: root, url: url, ancestors: Set([url.path]))]
+        while let (current, currentURL, ancestors) = queue.popFirst() {
             let resourceKeys = Set<URLResourceKey>([.nameKey, .isDirectoryKey])
             let options = FileManager.DirectoryEnumerationOptions([.skipsHiddenFiles, .skipsSubdirectoryDescendants])
-            let currentURL = url.appendingPathComponent(current.path)
             guard let directoryEnumerator = localFileManager.enumerator(at: currentURL, includingPropertiesForKeys: Array(resourceKeys), options: options) else {
                 continue
             }
             for case let fileURL as URL in directoryEnumerator {
-                let fileURL = fileURL.resolvingSymlinksInPath()
-                guard let resourceValues = try? fileURL.resourceValues(forKeys: resourceKeys),
-                      let isDirectory = resourceValues.isDirectory,
-                      let name = resourceValues.name
-                else {
+                // Keep the name and the path of the link itself, since pass uses symbolic
+                // links to share one password between several entries. Only the type comes
+                // from the target, because isDirectoryKey does not follow links.
+                let resolvedURL = fileURL.resolvingSymlinksInPath()
+                guard let name = (try? fileURL.resourceValues(forKeys: resourceKeys))?.name else {
                     continue
                 }
+                let isDirectory = (try? resolvedURL.resourceValues(forKeys: resourceKeys))?.isDirectory ?? false
                 // Ignore files that are not passwords, e.g., a README.md documenting the store.
                 guard isDirectory || (name as NSString).pathExtension.lowercased() == "gpg" else {
                     continue
@@ -187,12 +191,14 @@ public final class PasswordEntity: NSManagedObject, Identifiable {
                 passwordEntity.isDir = isDirectory
                 if isDirectory {
                     passwordEntity.name = name
-                    queue.append(passwordEntity)
+                    if !ancestors.contains(resolvedURL.path) {
+                        queue.append((passwordEntity, resolvedURL, ancestors.union([resolvedURL.path])))
+                    }
                 } else {
                     passwordEntity.name = (name as NSString).deletingPathExtension
                 }
                 passwordEntity.parent = current
-                passwordEntity.path = String(fileURL.path.dropFirst(url.path.count + 1))
+                passwordEntity.path = current.path.isEmpty ? name : "\(current.path)/\(name)"
             }
         }
         context.delete(root)

--- a/passKitTests/CoreData/PasswordEntityTest.swift
+++ b/passKitTests/CoreData/PasswordEntityTest.swift
@@ -178,6 +178,111 @@ final class PasswordEntityTest: CoreDataTestCase {
         XCTAssertEqual(allEntities.first!.name, "email")
     }
 
+    func testInitPasswordEntityCoreDataKeepsSymbolicLinkNames() throws {
+        let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+
+        // Sharing one password between several entries via symbolic links, as described in
+        // https://github.com/browserpass/browserpass-extension#how-to-use-the-same-username-and-password-pair-on-multiple-domains
+        //   example.com.gpg
+        //   example.net.gpg    -> example.com.gpg
+        //   web/
+        //     example.org.gpg  -> ../example.com.gpg
+        let webDir = rootDir.appendingPathComponent("web")
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        try Data("test".utf8).write(to: rootDir.appendingPathComponent("example.com.gpg"))
+        try FileManager.default.createSymbolicLink(atPath: rootDir.appendingPathComponent("example.net.gpg").path, withDestinationPath: "example.com.gpg")
+        try FileManager.default.createSymbolicLink(atPath: webDir.appendingPathComponent("example.org.gpg").path, withDestinationPath: "../example.com.gpg")
+
+        let context = controller.viewContext()
+        PasswordEntity.initPasswordEntityCoreData(url: rootDir, in: context)
+
+        let allEntities = PasswordEntity.fetchAll(in: context)
+        XCTAssertEqual(allEntities.filter { !$0.isDir }.count, 3)
+
+        let linkEntity = allEntities.first { $0.path == "example.net.gpg" }
+        XCTAssertNotNil(linkEntity)
+        XCTAssertEqual(linkEntity!.name, "example.net")
+        XCTAssertFalse(linkEntity!.isDir)
+        XCTAssertNil(linkEntity!.parent)
+
+        let nestedLinkEntity = allEntities.first { $0.path == "web/example.org.gpg" }
+        XCTAssertNotNil(nestedLinkEntity)
+        XCTAssertEqual(nestedLinkEntity!.name, "example.org")
+        XCTAssertEqual(nestedLinkEntity!.parent?.name, "web")
+
+        XCTAssertNotNil(allEntities.first { $0.path == "example.com.gpg" })
+    }
+
+    func testInitPasswordEntityCoreDataFollowsSymbolicLinksToDirectories() throws {
+        let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+
+        //   email/
+        //     work.gpg
+        //   mail       -> email
+        let emailDir = rootDir.appendingPathComponent("email")
+        try FileManager.default.createDirectory(at: emailDir, withIntermediateDirectories: true)
+        try Data("test".utf8).write(to: emailDir.appendingPathComponent("work.gpg"))
+        try FileManager.default.createSymbolicLink(atPath: rootDir.appendingPathComponent("mail").path, withDestinationPath: "email")
+
+        let context = controller.viewContext()
+        PasswordEntity.initPasswordEntityCoreData(url: rootDir, in: context)
+
+        let allEntities = PasswordEntity.fetchAll(in: context)
+
+        // The linked directory keeps its own name and is traversed under its own path.
+        let linkedDir = allEntities.first { $0.path == "mail" }
+        XCTAssertNotNil(linkedDir)
+        XCTAssertEqual(linkedDir!.name, "mail")
+        XCTAssertTrue(linkedDir!.isDir)
+        XCTAssertEqual(linkedDir!.children.count, 1)
+
+        let linkedChild = allEntities.first { $0.path == "mail/work.gpg" }
+        XCTAssertNotNil(linkedChild)
+        XCTAssertEqual(linkedChild!.name, "work")
+        XCTAssertNotNil(allEntities.first { $0.path == "email/work.gpg" })
+    }
+
+    func testInitPasswordEntityCoreDataTerminatesOnCircularSymbolicLinks() throws {
+        let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+
+        //   email/
+        //     up      -> ..
+        //   here      -> .
+        let emailDir = rootDir.appendingPathComponent("email")
+        try FileManager.default.createDirectory(at: emailDir, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(atPath: emailDir.appendingPathComponent("up").path, withDestinationPath: "..")
+        try FileManager.default.createSymbolicLink(atPath: rootDir.appendingPathComponent("here").path, withDestinationPath: ".")
+
+        let context = controller.viewContext()
+        PasswordEntity.initPasswordEntityCoreData(url: rootDir, in: context)
+
+        let allEntities = PasswordEntity.fetchAll(in: context)
+        XCTAssertEqual(Set(allEntities.map(\.path)), ["email", "email/up", "here"])
+    }
+
+    func testInitPasswordEntityCoreDataKeepsBrokenSymbolicLinks() throws {
+        let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+
+        try FileManager.default.createSymbolicLink(atPath: rootDir.appendingPathComponent("broken.gpg").path, withDestinationPath: "missing.gpg")
+
+        let context = controller.viewContext()
+        PasswordEntity.initPasswordEntityCoreData(url: rootDir, in: context)
+
+        let allEntities = PasswordEntity.fetchAll(in: context)
+        XCTAssertEqual(allEntities.count, 1)
+        XCTAssertEqual(allEntities.first!.name, "broken")
+        XCTAssertEqual(allEntities.first!.path, "broken.gpg")
+        XCTAssertFalse(allEntities.first!.isDir)
+    }
+
     func testInitPasswordEntityCoreDataHandlesEmptyDirectory() throws {
         let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)


### PR DESCRIPTION
Fixes #699.

`pass` users create symbolic links to share one password between several entries, as described in the [Browserpass README](https://github.com/browserpass/browserpass-extension?tab=readme-ov-file#how-to-use-the-same-username-and-password-pair-on-multiple-domains). Pass for iOS displayed all of them under the target's name, and browser autofill matched them under that name too, which defeats the purpose of the links.

## Cause

`initPasswordEntityCoreData` ran every enumerated file URL through `resolvingSymlinksInPath()`, so `example.net.gpg -> example.com.gpg` was stored with the name `example.com` and the path `example.com.gpg`.

## Fix

- The name and the path come from the link itself; only the type comes from the target, since `isDirectoryKey` does not follow links.
- Directories are enumerated through their resolved URL, so symbolically linked directories are still traversed — now under their own path instead of the target's.
- Paths are built from the parent entity rather than by slicing the resolved absolute path. The old slicing only worked because `resolvingSymlinksInPath()` also strips a leading `/private`; without it the paths came out mangled.
- Each directory carries the resolved paths of its ancestors, so a link pointing back up the tree (`up -> ..`, `here -> .`) terminates instead of recursing forever.

The traversal queue is now a `Deque`, so `swift-collections` 1.6.0 is added as a dependency and `DequeModule` is linked into passKit.

## Tests

Four new cases in `PasswordEntityTest`: the multi-domain layout from the Browserpass README (flat and nested links), symbolically linked directories, circular links, and broken links. Full suite passes on iPhone 17 Pro / iOS 26.5 (`passTests` 10, `passKitTests` 147, 0 failures).

## Not included

The issue also asks for a visual indicator on linked entries and for grouping links with their originals. Both need a new Core Data attribute plus user-facing strings across the localizations, so they are left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)